### PR TITLE
ci: establish documentation relay to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,11 +7,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: pages
   cancel-in-progress: false
@@ -20,6 +15,8 @@ jobs:
   build:
     if: github.repository == 'terok-ai/mkdocs-terok'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -60,6 +57,9 @@ jobs:
     if: github.repository == 'terok-ai/mkdocs-terok'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,12 +15,15 @@ concurrency:
 
 jobs:
   build:
-    if: github.repository == 'terok-ai/mkdocs-terok'
+    if: github.repository == 'terok-ai/mkdocs-terok' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         id: setup-python
@@ -56,7 +59,7 @@ jobs:
           path: site/
 
   deploy:
-    if: github.repository == 'terok-ai/mkdocs-terok'
+    if: github.repository == 'terok-ai/mkdocs-terok' && github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,69 @@
+# Pin third-party actions to full commit SHAs for supply-chain security.
+# GitHub-owned actions (actions/*) may use version tags.
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.repository == 'terok-ai/mkdocs-terok'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install dynamic versioning plugin
+        run: poetry self add "poetry-dynamic-versioning[plugin]>=1.0.0,<2.0.0"
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-docs-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
+
+      - name: Install dependencies
+        run: poetry install --with docs --no-interaction
+
+      - name: Build documentation
+        run: poetry run mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site/
+
+  deploy:
+    if: github.repository == 'terok-ai/mkdocs-terok'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,8 +4,10 @@ name: Docs
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   workflow_dispatch:
+
+permissions: {}
 
 concurrency:
   group: pages


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow that builds and deploys the docs site to GitHub Pages on merge to main
- Includes `workflow_dispatch` trigger for manual re-deployment
- Uses concurrency control to prevent overlapping deployments

## Details

The workflow has two jobs:
1. **build** — installs Poetry + docs deps, runs `mkdocs build --strict`, uploads the `site/` artifact
2. **deploy** — deploys the artifact to GitHub Pages via `actions/deploy-pages`

Follows the same conventions as the existing CI workflow (pinned third-party actions, Poetry caching, `if: github.repository` guard).

## Setup required

After merge, enable GitHub Pages in repo settings with **Source: GitHub Actions**.

## Test plan

- [x] Workflow syntax validated
- [x] Mirrors proven patterns from existing CI workflow
- [x] `make docs` builds cleanly (verified in previous PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated documentation pipeline that builds and deploys the site to GitHub Pages on pushes to the main branch and via manual trigger.
  * Builds run in strict mode to catch documentation issues earlier.
  * Third-party workflow steps are pinned to exact SHAs for reproducibility.
  * Caching and deterministic dependency installation improve reliability and speed.
  * Deployment publishes the site and surfaces the live documentation URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->