### PR TITLE
fix: realign coverage sensor array for Codecov source mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ format:
 # Run tests with coverage
 test:
 	mkdir -p $(REPORTS_DIR)
-	poetry run pytest tests/ --cov=mkdocs_terok --cov-report=term-missing --cov-report=xml:$(COVERAGE_XML) --junitxml=$(JUNIT_XML) -o junit_family=legacy
+	poetry run pytest tests/ --cov --cov-report=term-missing --cov-report=xml --junitxml=$(JUNIT_XML) -o junit_family=legacy
 
 # Check docstring coverage (minimum 95%)
 docstrings:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,13 @@ quote-style = "double"
 indent-style = "space"
 docstring-code-format = true
 
+[tool.coverage.run]
+source = ["mkdocs_terok"]
+relative_files = true
+
+[tool.coverage.xml]
+output = "reports/coverage.xml"
+
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"


### PR DESCRIPTION
## Summary

- Add `relative_files = true` to `[tool.coverage.run]` so coverage.py emits repo-relative paths
- Add `[tool.coverage.run] source` and `[tool.coverage.xml] output` config to centralize coverage settings
- Simplify Makefile test target to use pyproject.toml coverage config

## Problem

Codecov showed "No coverage report uploaded for this branch head commit" despite successful uploads because coverage.py was emitting absolute machine-specific paths (`/home/runner/work/...`) in the XML `<source>` element. Codecov couldn't map these to repo files.

## Fix

With `relative_files = true`, the XML now emits `<source></source>` (empty = repo root) and `filename="src/mkdocs_terok/..."` — standard relative paths Codecov can resolve.

## Test plan

- [x] `make test` — 34/34 pass, coverage XML verified with relative paths
- [x] `make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test coverage reporting configuration for enhanced code quality tracking across all packages.
  * Configured coverage reports to be generated in a standard, centralized location for easier access and analysis.
  * Enhanced dynamic versioning configuration with standardized pattern and style settings to ensure consistent version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->