### PR TITLE
fix: render YAML example fields without comment prefix

### DIFF
--- a/src/mkdocs_terok/config_reference.py
+++ b/src/mkdocs_terok/config_reference.py
@@ -161,11 +161,11 @@ def _md_escape(text: str) -> str:
 def _write_yaml_leaf(
     buf: io.StringIO, pad: str, name: str, field_info: FieldInfo, desc: str
 ) -> None:
-    """Write a single commented-out leaf field to the YAML example."""
+    """Write a leaf field with its description comment to the YAML example."""
     if desc:
         buf.write(f"{pad}# {_strip_rst(desc)}\n")
     default = _yaml_default(field_info)
-    buf.write(f"{pad}# {name}: {default}\n" if default else f"{pad}# {name}:\n")
+    buf.write(f"{pad}{name}: {default}\n" if default else f"{pad}{name}:\n")
 
 
 def _render_section_table(
@@ -271,7 +271,7 @@ def _render_yaml_fields(
     field_docs: dict[str, str] | None = None,
     indent: int = 0,
 ) -> None:
-    """Render a full commented YAML example, using dotpath for doc lookup."""
+    """Render a full annotated YAML example, using dotpath for doc lookup."""
     if field_docs is None:
         field_docs = {}
     pad = "  " * indent
@@ -308,7 +308,7 @@ def render_yaml_example(
         field_docs: Mapping of ``"section.field"`` dotpaths to descriptions.
 
     Returns:
-        YAML string with commented-out fields and descriptions.
+        YAML string with annotated fields and descriptions.
     """
     buf = io.StringIO()
     _render_yaml_fields(buf, model_class, field_docs=field_docs)

--- a/tests/test_config_reference.py
+++ b/tests/test_config_reference.py
@@ -52,15 +52,18 @@ def test_render_model_tables_with_field_docs() -> None:
     assert "Shutdown timeout in seconds" in result
 
 
-def test_render_yaml_example_produces_commented_yaml() -> None:
-    """YAML example should have commented-out fields."""
+def test_render_yaml_example_produces_annotated_yaml() -> None:
+    """YAML example should have uncommented fields with description comments."""
     result = render_yaml_example(_SampleModel)
 
-    assert "# name:" in result
-    assert "# count: 5" in result
+    assert "name:" in result
+    assert "count: 5" in result
     assert "inner:" in result
-    assert "# timeout: 30" in result
-    assert "# enabled: true" in result
+    assert "timeout: 30" in result
+    assert "enabled: true" in result
+    # Keys should NOT be commented out
+    assert "# name:" not in result
+    assert "# count:" not in result
 
 
 def test_render_yaml_example_with_field_docs() -> None:


### PR DESCRIPTION
## Summary

- Uncomment field keys in generated YAML examples so output is valid YAML with proper syntax highlighting
- Description comments above each field are preserved

## Before / After

**Before:** `# station_name: "Deep Space Nine"` (commented out, no syntax highlighting)
**After:** `station_name: "Deep Space Nine"` (valid YAML, highlighted)

## Test plan

- [x] `make test` — 34/34 pass (test updated to assert uncommented keys)
- [x] `make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * YAML configuration examples now display with uncommented fields and actual values instead of commented-out lines, providing clearer and more readable configuration references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->