### PR TITLE
fix: recalibrate tach config for v0.34 compatibility

### DIFF
--- a/src/mkdocs_terok/quality_report.py
+++ b/src/mkdocs_terok/quality_report.py
@@ -491,6 +491,8 @@ def _section_dependency_diagram(cfg: QualityReportConfig) -> str:
     result = _run(sys.executable, "-m", "tach", "show", "--mermaid", "-o", "-", cwd=cfg.root)
     if result.returncode != 0:
         output = (result.stdout + result.stderr).strip() or "no output"
+        if "No dependency rules" in output:
+            return "No cross-module dependencies to visualize.\n"
         return (
             f"!!! warning\n    tach show failed (exit {result.returncode}).\n\n```\n{output}\n```\n"
         )

--- a/tach.toml
+++ b/tach.toml
@@ -1,12 +1,13 @@
-[tool.tach]
 exact = true
+source_roots = ["src"]
 
 # Shared MkDocs documentation generators
 [[modules]]
 path = "mkdocs_terok"
 depends_on = []
 
-[[modules.interfaces]]
+[[interfaces]]
+from = ["mkdocs_terok"]
 expose = [
   "brand_css_path",
   "ci_map",


### PR DESCRIPTION
## Summary

- **Removed `[tool.tach]` wrapper** from `tach.toml` — standalone config files use top-level keys, not the `pyproject.toml` `[tool.*]` convention
- **Restructured `[[modules.interfaces]]` to top-level `[[interfaces]]`** with `from = [...]` array, matching tach 0.34's expected schema (`ModuleConfigOrBulk`)
- **Added `source_roots = ["src"]`** so tach locates the package under `src/`
- **Softened dependency diagram output** — single-module projects with no cross-module deps now show a clean status line instead of a warning admonition

## Test plan

- [x] `tach check` passes (all module boundaries validated)
- [x] `pytest` — 45 tests pass
- [x] `ruff check` — clean
- [ ] Verify quality report renders cleanly in docs build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency diagram display in quality reports when no cross-module dependencies exist, presenting a clearer message instead of error output.

* **Chores**
  * Updated internal project configuration for tooling setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->