### PR TITLE
chore: advance version designator to v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ gracefully to a warning admonition.
 ```toml
 # In your project's pyproject.toml
 [tool.poetry.group.docs.dependencies]
-mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.1.0/mkdocs_terok-0.1.0-py3-none-any.whl"}
+mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.2.0/mkdocs_terok-0.2.0-py3-none-any.whl"}
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "mkdocs-terok"
-version = "0.1.0"
+version = "0.2.0"
 description = "Shared MkDocs documentation generators for terok projects"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` version placeholder from `0.1.0` to `0.2.0`
- Update README installation URL to point to the `v0.2.0` release artifact

## Test plan

- [ ] Merge and tag `v0.2.0` to trigger release workflow
- [ ] Verify published wheel is installable from the release URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version updated to 0.2.0

* **Documentation**
  * Updated dependency references in documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->