### PR TITLE
ci: add REUSE compliance & license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mkdocs-terok
 
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![REUSE](https://api.reuse.software/badge/github.com/terok-ai/mkdocs-terok)](https://api.reuse.software/info/github.com/terok-ai/mkdocs-terok)
 [![codecov](https://codecov.io/gh/terok-ai/mkdocs-terok/graph/badge.svg)](https://codecov.io/gh/terok-ai/mkdocs-terok)
 
 Shared MkDocs documentation generators for terok projects.


### PR DESCRIPTION
## Summary

- Add Apache-2.0 license badge (shields.io)
- Add REUSE specification compliance badge (api.reuse.software)
- Both placed alongside the existing Codecov badge

REUSE lint passes (35/35 files compliant with spec v3.3).

Closes #7

## Test plan

- [x] `poetry run reuse lint` passes
- [ ] Verify badges render correctly on GitHub after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)