### PR TITLE
fix: treemap SVG path and mermaid zoom observer

### DIFF
--- a/src/mkdocs_terok/_assets/mermaid_zoom.js
+++ b/src/mkdocs_terok/_assets/mermaid_zoom.js
@@ -88,9 +88,9 @@
 
   // Initial scan once DOM + mermaid rendering settle.
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", () => setTimeout(scan, 500))
+    document.addEventListener("DOMContentLoaded", () => setTimeout(scan, 2000))
   } else {
-    setTimeout(scan, 500)
+    setTimeout(scan, 2000)
   }
 
   // Catch diagrams rendered after initial load (e.g. instant navigation).
@@ -100,7 +100,8 @@
         if (node.nodeType !== 1) continue
         if (
           (node.matches?.(".mermaid, pre.mermaid") && node.querySelector("svg")) ||
-          node.querySelector?.(".mermaid svg, pre.mermaid svg")
+          node.querySelector?.(".mermaid svg, pre.mermaid svg") ||
+          (node.tagName === "svg" && node.parentElement?.matches?.(".mermaid, pre.mermaid"))
         ) {
           setTimeout(scan, 200)
           return

--- a/src/mkdocs_terok/quality_report.py
+++ b/src/mkdocs_terok/quality_report.py
@@ -593,7 +593,7 @@ def _section_coverage_treemap(cfg: QualityReportConfig) -> tuple[str, dict[str, 
     if resolved_treemap and resolved_treemap.is_file():
         svg = resolved_treemap.read_text(encoding="utf-8")
         companion["coverage_treemap.svg"] = svg
-        src = "coverage_treemap.svg"
+        src = "../coverage_treemap.svg"
     elif cfg.codecov_repo:
         base = f"https://codecov.io/gh/{cfg.codecov_repo}"
         src = f"{base}/graphs/tree.svg"

--- a/tests/test_quality_report.py
+++ b/tests/test_quality_report.py
@@ -109,7 +109,7 @@ def test_quality_report_config_relative_root(
     [
         pytest.param(False, "", "not available", id="no-treemap-no-codecov"),
         pytest.param(False, "org/repo", "codecov.io", id="codecov-url-fallback"),
-        pytest.param(True, "", 'data="coverage_treemap.svg"', id="bundled-svg"),
+        pytest.param(True, "", 'data="../coverage_treemap.svg"', id="bundled-svg"),
     ],
 )
 def test_coverage_treemap_variants(


### PR DESCRIPTION
## Summary

- **Treemap SVG path**: the companion file is written to site root (`coverage_treemap.svg`), but the page embedding it lives at `quality-report/index.html`. The `<object data="coverage_treemap.svg">` resolved relative to the page directory, hitting a 404. Fixed by using `../coverage_treemap.svg` (works with MkDocs' default `use_directory_urls=true`).

- **Mermaid zoom observer**: Material 9.x inserts `<svg>` directly into existing `pre.mermaid` containers rather than adding new `.mermaid` nodes. The MutationObserver never matched these. Added detection for SVG nodes whose parent is a mermaid container. Also bumped the initial scan timeout from 500ms to 2000ms as a safety net for slower renderers.

## Test plan

- [x] `make check` passes (lint, 45 tests, docstrings, deadcode, REUSE)
- [ ] Verify treemap SVG loads on a deployed site with `use_directory_urls: true`
- [ ] Verify mermaid zoom buttons appear on Material 9.x with instant navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mermaid diagram detection and rendering reliability with enhanced timing handling.
  * Corrected coverage treemap path reference in generated quality reports to ensure proper asset linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->