### PR TITLE
Rename 'Code Quality Report' to 'Code Metrics'

### DIFF
--- a/src/mkdocs_terok/quality_report.py
+++ b/src/mkdocs_terok/quality_report.py
@@ -658,7 +658,7 @@ def generate_quality_report(config: QualityReportConfig | None = None) -> Qualit
     coverage_md, companion = _section_coverage_treemap(config)
 
     sections = [
-        "# Code Quality Report\n\n",
+        "# Code Metrics\n\n",
         f"*Generated: {now}*\n\n",
         "---\n\n",
         "## Lines of Code\n\n",

--- a/tests/test_quality_report.py
+++ b/tests/test_quality_report.py
@@ -69,7 +69,7 @@ def test_generate_quality_report_returns_result(tmp_path: Path) -> None:
     result = generate_quality_report(config)
 
     assert isinstance(result, QualityReportResult)
-    assert "# Code Quality Report" in result.markdown
+    assert "# Code Metrics" in result.markdown
     assert "Generated:" in result.markdown
 
 
@@ -409,5 +409,5 @@ def test_full_report_degrades_gracefully(tmp_path: Path) -> None:
     ):
         result = generate_quality_report(cfg)
     assert isinstance(result, QualityReportResult)
-    assert "# Code Quality Report" in result.markdown
+    assert "# Code Metrics" in result.markdown
     assert "!!! warning" in result.markdown


### PR DESCRIPTION
This PR renames the 'Code Quality Report' page to 'Code Metrics' to better reflect the content of the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the code quality report heading to "Code Metrics".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->