### PR TITLE
module_map: waypoint packages, file-type classification, domain grouping, CLI

### DIFF
--- a/src/mkdocs_terok/module_map.py
+++ b/src/mkdocs_terok/module_map.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import ast
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from enum import Enum, auto
 from pathlib import Path
 
 
@@ -23,6 +24,8 @@ class ModuleMapConfig:
     """Configuration for the module map generator."""
 
     src_root: Path = field(default_factory=lambda: Path.cwd() / "src")
+    tach_path: Path | None = None
+    no_tach: bool = False
     title: str = "Module Map"
 
 
@@ -34,8 +37,10 @@ def generate_module_map(config: ModuleMapConfig | None = None) -> str:
     """
     cfg = config or ModuleMapConfig()
     pkg_root = _detect_package_root(cfg.src_root)
-    layers = _discover_layers(cfg.src_root, pkg_root)
-    return _render(pkg_root, layers, cfg.title)
+    layers, label_root = _discover_layers(
+        cfg.src_root, pkg_root, tach_path=cfg.tach_path, no_tach=cfg.no_tach
+    )
+    return _render(pkg_root, label_root, layers, cfg.title)
 
 
 # ── Package root detection ──────────────────────────────
@@ -62,7 +67,10 @@ def _detect_package_root(src_root: Path) -> Path:
 def _discover_layers(
     src_root: Path,
     pkg_root: Path,
-) -> list[tuple[str, list[Path]]]:
+    *,
+    tach_path: Path | None = None,
+    no_tach: bool = False,
+) -> tuple[list[tuple[str, list[Path]]], Path]:
     """Discover source files grouped by architectural layer.
 
     With ``tach.toml``: assigns each file to a layer via longest-prefix
@@ -70,17 +78,23 @@ def _discover_layers(
     ``layers`` list.
 
     Without: groups by subdirectory, sorted alphabetically.
+
+    Returns ``(layers, label_root)`` where *label_root* is the base path
+    for computing dotted module labels — the tach source root when tach
+    is active, or *pkg_root* otherwise.
     """
     py_files = _collect_py_files(pkg_root)
-    tach = _read_tach_config(src_root)
-    if tach:
-        return _group_by_tach(py_files, src_root, tach)
-    return _group_by_directory(py_files, pkg_root)
+    if not no_tach:
+        tach = _parse_tach(tach_path) if tach_path else _read_tach_config(src_root)
+        if tach:
+            tach_src = _resolve_tach_src_root(tach)
+            return _group_by_tach(py_files, src_root, tach), tach_src
+    return _group_by_directory(py_files, pkg_root), pkg_root
 
 
 def _collect_py_files(pkg_root: Path) -> list[Path]:
-    """Collect all ``.py`` files under *pkg_root*, skipping ``__init__.py``."""
-    return [f for f in sorted(pkg_root.rglob("*.py")) if f.name != "__init__.py"]
+    """Collect all ``.py`` files under *pkg_root*, including ``__init__.py``."""
+    return sorted(pkg_root.rglob("*.py"))
 
 
 def _group_by_directory(
@@ -105,6 +119,8 @@ class _TachConfig:
 
     layers: list[str]
     module_layers: dict[str, str]  # dotted module path → layer name
+    source_roots: list[str] = field(default_factory=lambda: ["."])
+    config_dir: Path = field(default_factory=Path.cwd)  # directory containing tach.toml
 
 
 def _read_tach_config(src_root: Path) -> _TachConfig | None:
@@ -140,7 +156,26 @@ def _parse_tach(path: Path) -> _TachConfig | None:
         if mod_path and layer:
             module_layers[mod_path] = layer
 
-    return _TachConfig(layers=layers, module_layers=module_layers)
+    source_roots = data.get("source_roots", ["."])
+    return _TachConfig(
+        layers=layers,
+        module_layers=module_layers,
+        source_roots=source_roots,
+        config_dir=path.parent,
+    )
+
+
+def _resolve_tach_src_root(tach: _TachConfig) -> Path:
+    """Resolve the source root directory from tach configuration.
+
+    Uses the first ``source_roots`` entry relative to the tach.toml
+    directory.  Falls back to the tach.toml directory itself.
+    """
+    for root in tach.source_roots:
+        candidate = (tach.config_dir / root).resolve()
+        if candidate.is_dir():
+            return candidate
+    return tach.config_dir
 
 
 def _group_by_tach(
@@ -153,11 +188,12 @@ def _group_by_tach(
     tach defines layers top-down (highest first), but a module map
     reads better foundation-first, so we reverse the order.
     """
+    tach_src = _resolve_tach_src_root(tach)
     layer_files: dict[str, list[Path]] = {}
     unassigned: list[Path] = []
 
     for path in py_files:
-        layer = _file_to_layer(path, src_root, tach)
+        layer = _file_to_layer(path, tach_src, tach)
         if layer:
             layer_files.setdefault(layer, []).append(path)
         else:
@@ -180,7 +216,10 @@ def _group_by_tach(
 def _file_to_layer(path: Path, src_root: Path, tach: _TachConfig) -> str | None:
     """Determine which tach layer a file belongs to via longest-prefix match."""
     rel = path.relative_to(src_root)
-    dotted = ".".join(rel.with_suffix("").parts)
+    parts = rel.with_suffix("").parts
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    dotted = ".".join(parts)
 
     best_match = ""
     best_layer = None
@@ -194,34 +233,126 @@ def _file_to_layer(path: Path, src_root: Path, tach: _TachConfig) -> str | None:
     return best_layer
 
 
+# ── File-type classification ───────────────────────────
+
+
+class FileType(Enum):
+    """Module classification heuristic for rendering style."""
+
+    NARRATIVE = auto()
+    CATALOG = auto()
+    WAYPOINT = auto()
+
+
+_WAYPOINT_SIGNALS = frozenset(
+    {
+        "facade",
+        "re-export",
+        "delegates",
+        "coordinator",
+        "dispatcher",
+        "waypoint",
+    }
+)
+
+
+def _classify(module_doc: str, classes: list[tuple[str, str]], func_count: int) -> FileType:
+    """Classify a module as narrative, catalog, or waypoint.
+
+    Heuristics (not assertions):
+    - Waypoint: module docstring contains delegation/facade language
+    - Catalog: many types (>= 4), few public functions (<= 2)
+    - Narrative: everything else
+    """
+    doc_lower = module_doc.lower()
+    if any(signal in doc_lower for signal in _WAYPOINT_SIGNALS):
+        return FileType.WAYPOINT
+    if len(classes) >= 4 and func_count <= 2:
+        return FileType.CATALOG
+    return FileType.NARRATIVE
+
+
 # ── Docstring extraction ────────────────────────────────
 
 
 def _module_label(path: Path, pkg_root: Path) -> str:
     """Derive a dotted module label from a file path."""
     rel = path.relative_to(pkg_root)
-    return ".".join(rel.with_suffix("").parts)
+    parts = rel.with_suffix("").parts
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts) if parts else pkg_root.name
 
 
-def _extract_docstrings(path: Path) -> tuple[str, list[tuple[str, str]]]:
-    """Extract module and class docstrings via AST.
+def _extract_docstrings(path: Path) -> tuple[str, list[tuple[str, str]], int]:
+    """Extract module docstring, class docstrings, and public function count via AST.
 
-    Returns ``(module_doc, [(class_name, class_doc), ...])``.
+    Returns ``(module_doc, [(class_name, class_doc), ...], public_func_count)``.
     Files with syntax errors return empty results.
     """
     try:
         tree = ast.parse(path.read_text())
     except SyntaxError:
-        return ("", [])
+        return ("", [], 0)
 
     module_doc = ast.get_docstring(tree) or ""
     classes: list[tuple[str, str]] = []
+    func_count = 0
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, ast.ClassDef):
             doc = ast.get_docstring(node) or ""
             classes.append((node.name, doc))
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not node.name.startswith("_"):
+                func_count += 1
 
-    return (module_doc, classes)
+    return (module_doc, classes, func_count)
+
+
+# ── Domain grouping ────────────────────────────────────
+
+
+def _domain_groups(paths: list[Path], pkg_root: Path) -> list[tuple[str, list[Path]]]:
+    """Group paths within a layer by domain subpackage.
+
+    When a tach layer contains modules from multiple domain packages
+    (e.g. ``nft/constants`` at foundation AND ``nft/rules`` at core),
+    they are grouped under the domain name for contiguous rendering.
+
+    Returns ``[("", paths)]`` when grouping is unnecessary (all files
+    share one domain or none qualify).
+    """
+    # Identify domain packages: paths with at least two components
+    known_domains: set[str] = set()
+    for path in paths:
+        rel = path.relative_to(pkg_root)
+        parts = rel.parts
+        if len(parts) >= 2:
+            # First directory component below pkg_root is a potential domain
+            known_domains.add(parts[0])
+
+    if not known_domains:
+        return [("", paths)]
+
+    # Assign each path to its domain group, preserving order
+    groups: dict[str, list[Path]] = {}
+    order: list[str] = []
+    for path in paths:
+        rel = path.relative_to(pkg_root)
+        first = rel.parts[0] if len(rel.parts) >= 2 else ""
+        group = first if first in known_domains else ""
+
+        if group not in groups:
+            order.append(group)
+            groups[group] = []
+        groups[group].append(path)
+
+    # Single effective group → no visual grouping needed
+    non_trivial = [g for g in order if g or len(groups.get("", [])) > 1]
+    if len(non_trivial) <= 1:
+        return [("", paths)]
+
+    return [(g, groups[g]) for g in order]
 
 
 # ── Markdown rendering ──────────────────────────────────
@@ -229,6 +360,7 @@ def _extract_docstrings(path: Path) -> tuple[str, list[tuple[str, str]]]:
 
 def _render(
     pkg_root: Path,
+    label_root: Path,
     layers: list[tuple[str, list[Path]]],
     title: str,
 ) -> str:
@@ -241,7 +373,7 @@ def _render(
     ]
 
     for layer_name, paths in layers:
-        layer_lines = _render_layer(pkg_root, layer_name, paths)
+        layer_lines = _render_layer(pkg_root, label_root, layer_name, paths)
         if layer_lines:
             lines.extend(layer_lines)
 
@@ -250,38 +382,66 @@ def _render(
 
 def _render_layer(
     pkg_root: Path,
+    label_root: Path,
     layer_name: str,
     paths: list[Path],
 ) -> list[str]:
-    """Render a single layer section.  Returns empty list if no docs found."""
-    module_sections: list[str] = []
+    """Render a single layer section with optional domain grouping.
 
-    for path in paths:
-        if not path.is_file():
+    When a layer contains modules from multiple domain packages, each
+    domain gets a ``###`` subheading and modules render at ``####`` depth.
+    """
+    groups = _domain_groups(paths, pkg_root)
+    all_sections: list[str] = []
+
+    for group_name, group_paths in groups:
+        depth = 4 if group_name else 3
+        sections: list[str] = []
+        for path in group_paths:
+            if not path.is_file():
+                continue
+            section = _render_module(label_root, path, depth=depth)
+            if section:
+                sections.append(section)
+        if not sections:
             continue
-        section = _render_module(pkg_root, path)
-        if section:
-            module_sections.append(section)
+        if group_name:
+            heading = group_name.replace("_", " ").title()
+            all_sections.append(f"### {heading}\n")
+        all_sections.extend(sections)
 
-    if not module_sections:
+    if not all_sections:
         return []
 
     lines = [f"---\n\n## {layer_name}\n"]
-    lines.extend(module_sections)
+    lines.extend(all_sections)
     return lines
 
 
-def _render_module(pkg_root: Path, path: Path) -> str | None:
+def _render_module(pkg_root: Path, path: Path, *, depth: int = 3) -> str | None:
     """Render a single module section.  Returns None if no docs found."""
     label = _module_label(path, pkg_root)
-    module_doc, classes = _extract_docstrings(path)
+    module_doc, classes, func_count = _extract_docstrings(path)
     if not module_doc and not classes:
         return None
 
-    parts: list[str] = [f"### `{label}`\n"]
+    file_type = _classify(module_doc, classes, func_count)
+    renderer = _RENDERERS[file_type]
+    return renderer(label, module_doc, classes, depth=depth)
+
+
+def _render_narrative(
+    label: str,
+    module_doc: str,
+    classes: list[tuple[str, str]],
+    *,
+    depth: int = 3,
+) -> str:
+    """Render a narrative module: prose intro, then class subsections."""
+    hashes = "#" * depth
+    parts: list[str] = [f"{hashes} `{label}`\n"]
     if module_doc:
         parts.append(f"{module_doc}\n")
-
     for cls_name, cls_doc in classes:
         if not cls_doc:
             continue
@@ -292,5 +452,90 @@ def _render_module(pkg_root: Path, path: Path) -> str | None:
             for line in rest.splitlines():
                 parts.append(f"> {line}" if line.strip() else ">")
         parts.append("")
-
     return "\n".join(parts)
+
+
+def _render_catalog(
+    label: str,
+    module_doc: str,
+    classes: list[tuple[str, str]],
+    *,
+    depth: int = 3,
+) -> str:
+    """Render a catalog module: prose intro, then compact type table."""
+    hashes = "#" * depth
+    parts: list[str] = [f"{hashes} `{label}` *(catalog)*\n"]
+    if module_doc:
+        parts.append(f"{module_doc}\n")
+    if classes:
+        parts.append("| Type | Description |")
+        parts.append("|------|-------------|")
+        for cls_name, cls_doc in classes:
+            first_line = cls_doc.split("\n", 1)[0] if cls_doc else ""
+            parts.append(f"| `{cls_name}` | {first_line} |")
+        parts.append("")
+    return "\n".join(parts)
+
+
+def _render_waypoint(
+    label: str,
+    module_doc: str,
+    classes: list[tuple[str, str]],
+    *,
+    depth: int = 3,
+) -> str:
+    """Render a waypoint module: prose intro with collaborator map."""
+    hashes = "#" * depth
+    parts: list[str] = [f"{hashes} `{label}` *(waypoint)*\n"]
+    if module_doc:
+        parts.append(f"{module_doc}\n")
+    for cls_name, cls_doc in classes:
+        first_line = cls_doc.split("\n", 1)[0] if cls_doc else ""
+        parts.append(f"- **{cls_name}** — {first_line}")
+    if classes:
+        parts.append("")
+    return "\n".join(parts)
+
+
+_RENDERERS = {
+    FileType.NARRATIVE: _render_narrative,
+    FileType.CATALOG: _render_catalog,
+    FileType.WAYPOINT: _render_waypoint,
+}
+
+
+# ── CLI ────────────────────────────────────────────────
+
+
+def main() -> None:
+    """Generate a module map from the command line."""
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Generate a module map from source docstrings.",
+    )
+    parser.add_argument("src_root", type=Path, help="Source root directory (e.g. src/pkg)")
+    parser.add_argument("--tach", type=Path, default=None, help="Path to tach.toml")
+    parser.add_argument("--no-tach", action="store_true", help="Disable tach layer ordering")
+    parser.add_argument("--title", default="Module Map", help="Page title")
+    parser.add_argument("-o", "--output", type=Path, default=None, help="Output file (stdout)")
+
+    args = parser.parse_args()
+    config = ModuleMapConfig(
+        src_root=args.src_root.resolve(),
+        tach_path=args.tach.resolve() if args.tach else None,
+        no_tach=args.no_tach,
+        title=args.title,
+    )
+    result = generate_module_map(config)
+
+    if args.output:
+        args.output.write_text(result)
+        print(f"Written to {args.output}", file=sys.stderr)
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mkdocs_terok/module_map.py
+++ b/src/mkdocs_terok/module_map.py
@@ -256,14 +256,19 @@ _WAYPOINT_SIGNALS = frozenset(
 )
 
 
-def _classify(module_doc: str, classes: list[tuple[str, str]], func_count: int) -> FileType:
+def _classify(
+    path: Path, module_doc: str, classes: list[tuple[str, str]], func_count: int
+) -> FileType:
     """Classify a module as narrative, catalog, or waypoint.
 
     Heuristics (not assertions):
-    - Waypoint: module docstring contains delegation/facade language
+    - Waypoint: ``__init__.py`` with a docstring, or docstring contains
+      delegation/facade language
     - Catalog: many types (>= 4), few public functions (<= 2)
     - Narrative: everything else
     """
+    if path.name == "__init__.py" and module_doc:
+        return FileType.WAYPOINT
     doc_lower = module_doc.lower()
     if any(signal in doc_lower for signal in _WAYPOINT_SIGNALS):
         return FileType.WAYPOINT
@@ -425,7 +430,7 @@ def _render_module(pkg_root: Path, path: Path, *, depth: int = 3) -> str | None:
     if not module_doc and not classes:
         return None
 
-    file_type = _classify(module_doc, classes, func_count)
+    file_type = _classify(path, module_doc, classes, func_count)
     renderer = _RENDERERS[file_type]
     return renderer(label, module_doc, classes, depth=depth)
 

--- a/src/mkdocs_terok/module_map.py
+++ b/src/mkdocs_terok/module_map.py
@@ -215,7 +215,10 @@ def _group_by_tach(
 
 def _file_to_layer(path: Path, src_root: Path, tach: _TachConfig) -> str | None:
     """Determine which tach layer a file belongs to via longest-prefix match."""
-    rel = path.relative_to(src_root)
+    try:
+        rel = path.relative_to(src_root)
+    except ValueError:
+        return None
     parts = rel.with_suffix("").parts
     if parts and parts[-1] == "__init__":
         parts = parts[:-1]
@@ -472,11 +475,12 @@ def _render_catalog(
     parts: list[str] = [f"{hashes} `{label}` *(catalog)*\n"]
     if module_doc:
         parts.append(f"{module_doc}\n")
-    if classes:
+    documented = [(name, doc) for name, doc in classes if doc]
+    if documented:
         parts.append("| Type | Description |")
         parts.append("|------|-------------|")
-        for cls_name, cls_doc in classes:
-            first_line = cls_doc.split("\n", 1)[0] if cls_doc else ""
+        for cls_name, cls_doc in documented:
+            first_line = cls_doc.split("\n", 1)[0]
             parts.append(f"| `{cls_name}` | {first_line} |")
         parts.append("")
     return "\n".join(parts)
@@ -494,10 +498,11 @@ def _render_waypoint(
     parts: list[str] = [f"{hashes} `{label}` *(waypoint)*\n"]
     if module_doc:
         parts.append(f"{module_doc}\n")
-    for cls_name, cls_doc in classes:
-        first_line = cls_doc.split("\n", 1)[0] if cls_doc else ""
+    documented = [(name, doc) for name, doc in classes if doc]
+    for cls_name, cls_doc in documented:
+        first_line = cls_doc.split("\n", 1)[0]
         parts.append(f"- **{cls_name}** — {first_line}")
-    if classes:
+    if documented:
         parts.append("")
     return "\n".join(parts)
 

--- a/src/mkdocs_terok/module_map.py
+++ b/src/mkdocs_terok/module_map.py
@@ -36,7 +36,11 @@ def generate_module_map(config: ModuleMapConfig | None = None) -> str:
     by architectural layer.
     """
     cfg = config or ModuleMapConfig()
-    pkg_root = _detect_package_root(cfg.src_root)
+    pkg_root = (
+        cfg.src_root
+        if (cfg.src_root / "__init__.py").is_file()
+        else _detect_package_root(cfg.src_root)
+    )
     layers, label_root = _discover_layers(
         cfg.src_root, pkg_root, tach_path=cfg.tach_path, no_tach=cfg.no_tach
     )
@@ -85,7 +89,12 @@ def _discover_layers(
     """
     py_files = _collect_py_files(pkg_root)
     if not no_tach:
-        tach = _parse_tach(tach_path) if tach_path else _read_tach_config(src_root)
+        if tach_path:
+            tach = _parse_tach(tach_path)
+            if tach is None:
+                raise ValueError(f"Could not load tach config: {tach_path}")
+        else:
+            tach = _read_tach_config(src_root)
         if tach:
             tach_src = _resolve_tach_src_root(tach)
             return _group_by_tach(py_files, tach), tach_src
@@ -327,8 +336,9 @@ def _domain_groups(paths: list[Path], pkg_root: Path) -> list[tuple[str, list[Pa
     (e.g. ``nft/constants`` at foundation AND ``nft/rules`` at core),
     they are grouped under the domain name for contiguous rendering.
 
-    Returns ``[("", paths)]`` when grouping is unnecessary (all files
-    share one domain or none qualify).
+    Returns ``[("", paths)]`` when visual grouping is unnecessary:
+    no subpackages exist, all files share one domain, or only one
+    non-trivial group would be shown.
     """
     # Identify domain packages: paths with at least two components
     known_domains: set[str] = set()

--- a/src/mkdocs_terok/module_map.py
+++ b/src/mkdocs_terok/module_map.py
@@ -88,7 +88,7 @@ def _discover_layers(
         tach = _parse_tach(tach_path) if tach_path else _read_tach_config(src_root)
         if tach:
             tach_src = _resolve_tach_src_root(tach)
-            return _group_by_tach(py_files, src_root, tach), tach_src
+            return _group_by_tach(py_files, tach), tach_src
     return _group_by_directory(py_files, pkg_root), pkg_root
 
 
@@ -156,7 +156,8 @@ def _parse_tach(path: Path) -> _TachConfig | None:
         if mod_path and layer:
             module_layers[mod_path] = layer
 
-    source_roots = data.get("source_roots", ["."])
+    raw_roots = data.get("source_roots", ["."])
+    source_roots = raw_roots if isinstance(raw_roots, list) else ["."]
     return _TachConfig(
         layers=layers,
         module_layers=module_layers,
@@ -180,7 +181,6 @@ def _resolve_tach_src_root(tach: _TachConfig) -> Path:
 
 def _group_by_tach(
     py_files: list[Path],
-    src_root: Path,
     tach: _TachConfig,
 ) -> list[tuple[str, list[Path]]]:
     """Assign files to tach layers and order by the ``layers`` list.

--- a/tests/test_module_map.py
+++ b/tests/test_module_map.py
@@ -267,7 +267,7 @@ def test_group_by_tach_unassigned_files(tmp_path: Path) -> None:
         config_dir=tmp_path,
     )
     py_files = _collect_py_files(pkg)
-    layers = _group_by_tach(py_files, src, tach)
+    layers = _group_by_tach(py_files, tach)
     layer_names = [name for name, _files in layers]
 
     assert "(other)" in layer_names
@@ -294,7 +294,7 @@ def test_group_by_tach_orders_by_layer(tmp_path: Path) -> None:
         config_dir=tmp_path,
     )
     py_files = _collect_py_files(pkg)
-    layers = _group_by_tach(py_files, src, tach)
+    layers = _group_by_tach(py_files, tach)
     layer_names = [name for name, _files in layers]
 
     assert layer_names == ["common", "core", "support", "cli"]

--- a/tests/test_module_map.py
+++ b/tests/test_module_map.py
@@ -428,24 +428,37 @@ def test_generate_module_map_with_tach(tmp_path: Path, monkeypatch: pytest.Monke
 
 def test_classify_waypoint_from_docstring() -> None:
     """Modules whose docstring contains delegation language are waypoints."""
-    assert _classify("Public API facade. Delegates to collaborators.", [], 0) == FileType.WAYPOINT
-    assert _classify("Waypoint for the nft subsystem.", [], 0) == FileType.WAYPOINT
-    assert _classify("Re-export public symbols.", [], 0) == FileType.WAYPOINT
+    p = Path("mod.py")
+    assert (
+        _classify(p, "Public API facade. Delegates to collaborators.", [], 0) == FileType.WAYPOINT
+    )
+    assert _classify(p, "Waypoint for the nft subsystem.", [], 0) == FileType.WAYPOINT
+    assert _classify(p, "Re-export public symbols.", [], 0) == FileType.WAYPOINT
+
+
+def test_classify_waypoint_from_init() -> None:
+    """__init__.py with a docstring is always classified as waypoint."""
+    init = Path("pkg/__init__.py")
+    assert _classify(init, "Some package.", [], 5) == FileType.WAYPOINT
+    # Without a docstring, __init__.py falls through to default
+    assert _classify(init, "", [], 0) == FileType.NARRATIVE
 
 
 def test_classify_catalog_from_class_count() -> None:
     """Modules with many classes and few functions are catalogs."""
+    p = Path("types.py")
     classes = [("A", "a"), ("B", "b"), ("C", "c"), ("D", "d")]
-    assert _classify("Types module.", classes, 0) == FileType.CATALOG
-    assert _classify("Types module.", classes, 2) == FileType.CATALOG
+    assert _classify(p, "Types module.", classes, 0) == FileType.CATALOG
+    assert _classify(p, "Types module.", classes, 2) == FileType.CATALOG
     # Too many functions → narrative
-    assert _classify("Types module.", classes, 3) == FileType.NARRATIVE
+    assert _classify(p, "Types module.", classes, 3) == FileType.NARRATIVE
 
 
 def test_classify_narrative_default() -> None:
     """Modules that match no special pattern default to narrative."""
-    assert _classify("Regular module.", [("Foo", "foo")], 5) == FileType.NARRATIVE
-    assert _classify("", [], 0) == FileType.NARRATIVE
+    p = Path("mod.py")
+    assert _classify(p, "Regular module.", [("Foo", "foo")], 5) == FileType.NARRATIVE
+    assert _classify(p, "", [], 0) == FileType.NARRATIVE
 
 
 # ── Renderers ──────────────────────────────────────────

--- a/tests/test_module_map.py
+++ b/tests/test_module_map.py
@@ -11,17 +11,23 @@ from textwrap import dedent
 import pytest
 
 from mkdocs_terok.module_map import (
+    FileType,
     ModuleMapConfig,
+    _classify,
     _collect_py_files,
     _detect_package_root,
+    _domain_groups,
     _extract_docstrings,
     _file_to_layer,
     _group_by_directory,
     _group_by_tach,
     _module_label,
     _parse_tach,
+    _render_catalog,
     _render_layer,
     _render_module,
+    _render_narrative,
+    _render_waypoint,
     _TachConfig,
     generate_module_map,
 )
@@ -39,6 +45,18 @@ def test_module_label_single_file() -> None:
     """Top-level file produces a single-component label."""
     pkg = Path("/src/mypackage")
     assert _module_label(pkg / "utils.py", pkg) == "utils"
+
+
+def test_module_label_init_file() -> None:
+    """__init__.py labels use the package name, not __init__."""
+    pkg = Path("/src/mypackage")
+    assert _module_label(pkg / "core" / "__init__.py", pkg) == "core"
+
+
+def test_module_label_root_init() -> None:
+    """Root __init__.py uses the package directory name."""
+    pkg = Path("/src/mypackage")
+    assert _module_label(pkg / "__init__.py", pkg) == "mypackage"
 
 
 # ── _detect_package_root ────────────────────────────────
@@ -93,25 +111,44 @@ def test_extract_docstrings_module_and_classes(tmp_path: Path) -> None:
             pass
     ''')
     )
-    module_doc, classes = _extract_docstrings(src)
+    module_doc, classes, func_count = _extract_docstrings(src)
     assert module_doc == "Module docstring."
     assert classes == [("Foo", "Foo does things."), ("Bar", "")]
+    assert func_count == 0
 
 
 def test_extract_docstrings_syntax_error(tmp_path: Path) -> None:
     """Syntax errors produce empty results without crashing."""
     src = tmp_path / "broken.py"
     src.write_text("def f(:\n")
-    module_doc, classes = _extract_docstrings(src)
+    module_doc, classes, func_count = _extract_docstrings(src)
     assert module_doc == ""
     assert classes == []
+    assert func_count == 0
+
+
+def test_extract_docstrings_counts_public_functions(tmp_path: Path) -> None:
+    """Public function count excludes private (underscore-prefixed) functions."""
+    src = tmp_path / "funcs.py"
+    src.write_text(
+        dedent('''\
+        """Module with functions."""
+
+        def public_one(): pass
+        def public_two(): pass
+        def _private(): pass
+        async def public_async(): pass
+    ''')
+    )
+    _, _, func_count = _extract_docstrings(src)
+    assert func_count == 3
 
 
 # ── _collect_py_files ───────────────────────────────────
 
 
-def test_collect_py_files_skips_init(tmp_path: Path) -> None:
-    """__init__.py files are excluded from collection."""
+def test_collect_py_files_includes_init(tmp_path: Path) -> None:
+    """__init__.py files are included in collection."""
     (tmp_path / "__init__.py").touch()
     (tmp_path / "core.py").touch()
     sub = tmp_path / "sub"
@@ -121,7 +158,7 @@ def test_collect_py_files_skips_init(tmp_path: Path) -> None:
 
     files = _collect_py_files(tmp_path)
     names = [f.name for f in files]
-    assert "__init__.py" not in names
+    assert "__init__.py" in names
     assert "core.py" in names
     assert "engine.py" in names
 
@@ -164,6 +201,8 @@ def tach_config() -> _TachConfig:
             "mypkg": "support",
             "mypkg.cli": "cli",
         },
+        source_roots=["src"],
+        config_dir=Path("/"),
     )
 
 
@@ -224,6 +263,8 @@ def test_group_by_tach_unassigned_files(tmp_path: Path) -> None:
     tach = _TachConfig(
         layers=["core"],
         module_layers={"mypkg.core": "core"},
+        source_roots=["src"],
+        config_dir=tmp_path,
     )
     py_files = _collect_py_files(pkg)
     layers = _group_by_tach(py_files, src, tach)
@@ -232,7 +273,7 @@ def test_group_by_tach_unassigned_files(tmp_path: Path) -> None:
     assert "(other)" in layer_names
 
 
-def test_group_by_tach_orders_by_layer(tmp_path: Path, tach_config: _TachConfig) -> None:
+def test_group_by_tach_orders_by_layer(tmp_path: Path) -> None:
     """Files are grouped and ordered according to the tach layers list."""
     src = tmp_path / "src"
     pkg = src / "mypkg"
@@ -241,8 +282,19 @@ def test_group_by_tach_orders_by_layer(tmp_path: Path, tach_config: _TachConfig)
         d.mkdir(parents=True)
         (d / f"{subdir}_mod.py").write_text(f'"""Module in {subdir}."""\n')
 
+    tach = _TachConfig(
+        layers=["cli", "support", "core", "common"],
+        module_layers={
+            "mypkg.common": "common",
+            "mypkg.core": "core",
+            "mypkg.lib": "support",
+            "mypkg.cli": "cli",
+        },
+        source_roots=["src"],
+        config_dir=tmp_path,
+    )
     py_files = _collect_py_files(pkg)
-    layers = _group_by_tach(py_files, src, tach_config)
+    layers = _group_by_tach(py_files, src, tach)
     layer_names = [name for name, _files in layers]
 
     assert layer_names == ["common", "core", "support", "cli"]
@@ -301,7 +353,7 @@ def test_render_layer_empty_when_no_docs(tmp_path: Path) -> None:
     """Layer with only undocumented files returns empty list."""
     src = tmp_path / "bare.py"
     src.write_text("x = 1\n")
-    assert _render_layer(tmp_path, "empty_layer", [src]) == []
+    assert _render_layer(tmp_path, tmp_path, "empty_layer", [src]) == []
 
 
 def test_render_module_no_docs(tmp_path: Path) -> None:
@@ -369,3 +421,167 @@ def test_generate_module_map_with_tach(tmp_path: Path, monkeypatch: pytest.Monke
     common_pos = result.index("## common")
     core_pos = result.index("## core")
     assert common_pos < core_pos
+
+
+# ── _classify ──────────────────────────────────────────
+
+
+def test_classify_waypoint_from_docstring() -> None:
+    """Modules whose docstring contains delegation language are waypoints."""
+    assert _classify("Public API facade. Delegates to collaborators.", [], 0) == FileType.WAYPOINT
+    assert _classify("Waypoint for the nft subsystem.", [], 0) == FileType.WAYPOINT
+    assert _classify("Re-export public symbols.", [], 0) == FileType.WAYPOINT
+
+
+def test_classify_catalog_from_class_count() -> None:
+    """Modules with many classes and few functions are catalogs."""
+    classes = [("A", "a"), ("B", "b"), ("C", "c"), ("D", "d")]
+    assert _classify("Types module.", classes, 0) == FileType.CATALOG
+    assert _classify("Types module.", classes, 2) == FileType.CATALOG
+    # Too many functions → narrative
+    assert _classify("Types module.", classes, 3) == FileType.NARRATIVE
+
+
+def test_classify_narrative_default() -> None:
+    """Modules that match no special pattern default to narrative."""
+    assert _classify("Regular module.", [("Foo", "foo")], 5) == FileType.NARRATIVE
+    assert _classify("", [], 0) == FileType.NARRATIVE
+
+
+# ── Renderers ──────────────────────────────────────────
+
+
+def test_render_narrative_output() -> None:
+    """Narrative renderer produces prose with class blockquotes."""
+    result = _render_narrative(
+        "pkg.engine", "The engine.", [("Engine", "Main engine.\n\nDetails.")]
+    )
+    assert "### `pkg.engine`" in result
+    assert "The engine." in result
+    assert "**Engine** — Main engine." in result
+    assert "> Details." in result
+
+
+def test_render_catalog_output() -> None:
+    """Catalog renderer produces a markdown table."""
+    classes = [("Foo", "First."), ("Bar", "Second.")]
+    result = _render_catalog("pkg.types", "Type definitions.", classes)
+    assert "*(catalog)*" in result
+    assert "| Type | Description |" in result
+    assert "| `Foo` | First. |" in result
+    assert "| `Bar` | Second. |" in result
+
+
+def test_render_waypoint_output() -> None:
+    """Waypoint renderer produces a bullet list."""
+    classes = [("Shield", "Public API.")]
+    result = _render_waypoint("pkg", "Facade. Delegates to collaborators.", classes)
+    assert "*(waypoint)*" in result
+    assert "- **Shield** — Public API." in result
+
+
+def test_render_module_dispatches_by_type(tmp_path: Path) -> None:
+    """_render_module classifies and dispatches to the correct renderer."""
+    waypoint = tmp_path / "facade.py"
+    waypoint.write_text('"""Public facade. Delegates to engine."""\n')
+    result = _render_module(tmp_path, waypoint)
+    assert result is not None
+    assert "*(waypoint)*" in result
+
+    catalog = tmp_path / "types.py"
+    catalog.write_text(
+        dedent('''\
+        """Type definitions."""
+        class A:
+            """A."""
+        class B:
+            """B."""
+        class C:
+            """C."""
+        class D:
+            """D."""
+    ''')
+    )
+    result = _render_module(tmp_path, catalog)
+    assert result is not None
+    assert "*(catalog)*" in result
+
+
+def test_render_module_depth_parameter(tmp_path: Path) -> None:
+    """Depth parameter controls heading level."""
+    src = tmp_path / "mod.py"
+    src.write_text('"""A module."""\n')
+    result_h3 = _render_module(tmp_path, src, depth=3)
+    result_h4 = _render_module(tmp_path, src, depth=4)
+    assert result_h3 is not None
+    assert result_h4 is not None
+    assert result_h3.startswith("### ")
+    assert result_h4.startswith("#### ")
+
+
+# ── _domain_groups ─────────────────────────────────────
+
+
+def test_domain_groups_multiple_domains(tmp_path: Path) -> None:
+    """Files from multiple subpackages produce named groups."""
+    nft = tmp_path / "nft"
+    dns = tmp_path / "dns"
+    nft.mkdir()
+    dns.mkdir()
+    paths = [
+        nft / "constants.py",
+        nft / "rules.py",
+        dns / "resolver.py",
+    ]
+    for p in paths:
+        p.touch()
+
+    groups = _domain_groups(paths, tmp_path)
+    group_names = [name for name, _ in groups]
+    assert "nft" in group_names
+    assert "dns" in group_names
+
+
+def test_domain_groups_single_domain(tmp_path: Path) -> None:
+    """Files from a single domain produce one unnamed group."""
+    sub = tmp_path / "core"
+    sub.mkdir()
+    paths = [sub / "a.py", sub / "b.py"]
+    for p in paths:
+        p.touch()
+
+    groups = _domain_groups(paths, tmp_path)
+    assert len(groups) == 1
+    assert groups[0][0] == ""
+
+
+def test_domain_groups_flat_files(tmp_path: Path) -> None:
+    """Files directly under pkg_root produce one unnamed group."""
+    paths = [tmp_path / "a.py", tmp_path / "b.py"]
+    for p in paths:
+        p.touch()
+
+    groups = _domain_groups(paths, tmp_path)
+    assert len(groups) == 1
+    assert groups[0][0] == ""
+
+
+# ── CLI ────────────────────────────────────────────────
+
+
+def test_main_writes_to_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI --output writes markdown to the specified file."""
+    from mkdocs_terok.module_map import main
+
+    pkg = tmp_path / "src" / "mypkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").touch()
+    (pkg / "engine.py").write_text('"""Engine module."""\n')
+    out = tmp_path / "output.md"
+
+    monkeypatch.setattr("sys.argv", ["module_map", str(pkg), "--no-tach", "-o", str(out)])
+    main()
+
+    content = out.read_text()
+    assert "# Module Map" in content
+    assert "engine" in content


### PR DESCRIPTION
## Summary

- Include `__init__.py` files in collection — waypoint packages contain collaborator maps essential for understanding domain structure
- Classify modules as narrative, catalog, or waypoint via docstring heuristics and render each type distinctly (compact type tables for catalogs, collaborator bullet lists for waypoints)
- Group modules by domain subpackage within tach layers when layers and packages are orthogonal (`### Domain` / `#### module` hierarchy)
- Add CLI entry point: `python -m mkdocs_terok.module_map src/pkg --tach tach.toml -o output.md`

## Test plan

- [x] All 109 tests pass (`make check`)
- [x] 97% coverage on module_map.py
- [x] 100% docstring coverage
- [x] REUSE compliant
- [x] Tested against terok-shield codebase (correct layer ordering, file-type classification, domain grouping)
- [ ] Verify MkDocs plugin integration (module_map page generation via `mkdocs build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI with options to specify/disable tach usage, set a title, and write output; the module can run as a standalone script.
  * Module classification now uses docstrings plus public-function counts and renders modules as narrative, catalog, or waypoint formats.
  * Layer rendering supports domain-based sub-grouping with adjusted heading depths; init files are now included in module discovery.

* **Tests**
  * Expanded test coverage for classification, renderers, grouping behavior, file collection, and CLI output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->