### PR TITLE
chore: add root LICENSE symlink for GitHub detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+LICENSES/0BSD.txt


### PR DESCRIPTION
GitHub's licensee doesn't scan LICENSES/ (REUSE dir), so the license chip doesn't render. Symlinking LICENSE -> LICENSES/0BSD.txt satisfies both GitHub and REUSE without duplicating the text.