### PR TITLE
ci: fix no-git-deps reusable workflow permission inheritance + .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+reviews:
+  auto_review:
+    labels:
+      - "!automated-release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ concurrency:
 jobs:
   no-git-deps:
     uses: ./.github/workflows/no-git-deps.yml
+    permissions:
+      contents: read
 
   build:
     needs: no-git-deps


### PR DESCRIPTION
The release.yml workflow fails immediately on tag push with the reusable workflow rejecting the inherited contents:none permission while its scan job requests contents:read. One job-level grant on the caller fixes it.

Also adds the missing .coderabbit.yaml so the automated-release label is honoured (other terok-ai repos already have this config).