### PR TITLE
ci(release): scope publish jobs to workflow_dispatch only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,7 @@ jobs:
 
   github-release:
     needs: build
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && inputs.target == 'gh-only')
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -84,9 +82,7 @@ jobs:
 
   pypi-publish:
     needs: build
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'pypi'
     runs-on: ubuntu-latest
     environment: pypi   # OIDC subject narrowing + required-reviewer gate
     permissions:


### PR DESCRIPTION
Stops the workflow's pypi-publish job from queueing a waiting-for-approval run on every tag push (the chain script's --target=gh-only mode produced this). Tag push now triggers github-release only; PyPI/TestPyPI publish is always explicit via workflow_dispatch.

Companion script-side fix lives in terok-warden/terok-toolbox `fix/wait-for-release-run-no-tui`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow reliability and automated release triggering mechanisms for better deployment control.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/mkdocs-terok/pull/45)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->