### PR TITLE
docs(readme): drop wheel-URL pin from Installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ gracefully to a warning admonition.
 
 ## Installation
 
+Add to your project's `pyproject.toml` as a docs-build dependency:
+
 ```toml
-# In your project's pyproject.toml
 [tool.poetry.group.docs.dependencies]
-mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.3.0/mkdocs_terok-0.3.0-py3-none-any.whl"}
+mkdocs-terok = "^0.5"
 ```
 
 ## License


### PR DESCRIPTION
The Installation snippet was a Poetry URL-pin to a hardcoded GH-release wheel (v0.3.0). Replace with the canonical `pip install mkdocs-terok` now that the package is on PyPI/TestPyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Installation example to use a Poetry pyproject.toml docs-build entry with a version constraint (e.g., `mkdocs-terok = "^0.5"`) and adjusted surrounding prose for clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/mkdocs-terok/pull/50)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->