### PR TITLE
ci(release): restore gh-only dispatch path + drop github-release actor check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
       target:
         description: "What to publish"
         type: choice
-        options: [pypi, testpypi, gh-only]
+        options: [pypi, testpypi]
         default: pypi
 
 # Empty default; each job re-grants only what it needs.


### PR DESCRIPTION
Two coupled adjustments — see commit message. Pairs with the same change being applied to the open fix PRs on the other five repos.