### PR TITLE
docs: align REUSE badge alt text with sibling repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mkdocs-terok
 
 [![License: 0BSD](https://img.shields.io/badge/License-0BSD-green.svg)](https://opensource.org/license/0bsd)
-[![REUSE](https://api.reuse.software/badge/github.com/terok-ai/mkdocs-terok)](https://api.reuse.software/info/github.com/terok-ai/mkdocs-terok)
+[![REUSE status](https://api.reuse.software/badge/github.com/terok-ai/mkdocs-terok)](https://api.reuse.software/info/github.com/terok-ai/mkdocs-terok)
 [![codecov](https://codecov.io/gh/terok-ai/mkdocs-terok/graph/badge.svg)](https://codecov.io/gh/terok-ai/mkdocs-terok)
 
 Shared [ProperDocs](https://properdocs.org/) documentation generators for terok projects.


### PR DESCRIPTION
## Summary
- Use \`REUSE status\` (matching every other terok-ai repo) instead of the bare \`REUSE\` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation badge in README.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/mkdocs-terok/pull/55)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->