### PR TITLE
fix(versioning): match alpha tags in poetry-dynamic-versioning pattern

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ output = "reports/coverage.xml"
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
-pattern = "^v(?P<base>\\d+\\.\\d+\\.\\d+)$"
+pattern = "^v(?P<base>\\d+\\.\\d+\\.\\d+)(?:(?P<stage>a)(?P<revision>\\d+))?$"
 style = "pep440"
 
 [tool.poetry-dynamic-versioning.substitution]


### PR DESCRIPTION
## Summary
- `[tool.poetry-dynamic-versioning].pattern` was strict-final-only: `^v(?P<base>\d+\.\d+\.\d+)$`. Alpha tags (`v0.0.141a1`) failed to match, so dynamic-versioning fell back to "no matching tag" and produced a `0.0.140.post4.dev0+<sha>` wheel instead of `0.0.141a1`.
- Extend the pattern to optionally capture an `aN` suffix: `^v(?P<base>\d+\.\d+\.\d+)(?:(?P<stage>a)(?P<revision>\d+))?$`. Final tags still match unchanged; alpha tags now parse correctly.

## Why now
First alpha cut via `terok-release quick ... --version-step alpha` exposed the issue on `terok-executor` v0.0.141a1 — the released wheel was named `terok_executor-0.0.140.post4.dev0+8ec8a07-py3-none-any.whl` instead of `terok_executor-0.0.141a1-py3-none-any.whl`, locking the chain script in `wait_for_wheel`.

## Test plan
- [x] Regex matches both `v0.7.8` (existing final tags) and `v0.0.141a1` (new alpha tags); rejects `v0.0.141b1` / `v0.0.141.dev1` which are out of scope.
- [ ] Next alpha cut produces a correctly-named wheel.

## Followup
The botched v0.0.141a1 release on terok-executor needs to be deleted (release + tag) and re-cut once this lands, so the wheel filename is right.