### PR TITLE
feat: sibling-decoupled inventory publishing

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: 0BSD
+
+# Calls the reusable inventory-publish workflow on every master merge,
+# in parallel with `docs.yml`.  The two jobs are intentionally
+# decoupled: a failed Pages deploy doesn't stale the inventory bucket,
+# and an inventory hiccup doesn't stale the docs site.
+
+name: Publish inventory
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  publish:
+    if: github.repository == 'terok-ai/mkdocs-terok' && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/publish-inventory.yml
+    secrets:
+      INVENTORY_WRITE_TOKEN: ${{ secrets.INVENTORY_WRITE_TOKEN }}

--- a/.github/workflows/publish-inventory.yml
+++ b/.github/workflows/publish-inventory.yml
@@ -67,7 +67,9 @@ jobs:
           key: venv-inventory-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
 
       - name: Install dependencies
-        run: poetry install ${{ inputs.poetry-install-args }}
+        env:
+          INSTALL_ARGS: ${{ inputs.poetry-install-args }}
+        run: poetry install $INSTALL_ARGS
 
       - name: Generate inventory
         run: poetry run python -m mkdocs_terok.inventory -o /tmp/objects.inv

--- a/.github/workflows/publish-inventory.yml
+++ b/.github/workflows/publish-inventory.yml
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: 0BSD
+
+# Reusable workflow: build a sibling-decoupled objects.inv for the calling
+# repo and PUT it into terok-ai/docs-inventories via the GitHub Contents
+# API.  The bucket repo holds one .inv file per source repo at
+# `<repo>/objects.inv`; downstream `properdocs.yml` files read it via
+# `https://raw.githubusercontent.com/terok-ai/docs-inventories/main/<repo>/objects.inv`.
+#
+# Pin third-party actions to full commit SHAs.  GitHub-owned actions
+# (actions/*) may use version tags.
+
+name: Publish inventory (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version used for the inventory build"
+        type: string
+        default: "3.12"
+      poetry-install-args:
+        description: "Extra args passed to ``poetry install``"
+        type: string
+        default: "--with docs --no-interaction"
+      bucket-repo:
+        description: "Owner/name of the inventory bucket repo"
+        type: string
+        default: "terok-ai/docs-inventories"
+    secrets:
+      INVENTORY_WRITE_TOKEN:
+        description: "PAT with `Contents: write` on the bucket repo"
+        required: true
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install dynamic versioning plugin
+        run: poetry self add "poetry-dynamic-versioning[plugin]>=1.0.0,<2.0.0"
+
+      - name: Install dependencies
+        run: poetry install ${{ inputs.poetry-install-args }}
+
+      - name: Generate inventory
+        run: poetry run python -m mkdocs_terok.inventory -o /tmp/objects.inv
+
+      - name: Publish to ${{ inputs.bucket-repo }}
+        env:
+          GH_TOKEN: ${{ secrets.INVENTORY_WRITE_TOKEN }}
+          BUCKET: ${{ inputs.bucket-repo }}
+        run: |
+          set -euo pipefail
+          repo_name="${GITHUB_REPOSITORY##*/}"
+          path="${repo_name}/objects.inv"
+          api="repos/${BUCKET}/contents/${path}"
+
+          # GET current SHA so PUT updates instead of conflicting; absent
+          # on first publish, in which case we PUT without a sha field.
+          sha=$(gh api "$api" --jq .sha 2>/dev/null || true)
+
+          payload=(
+            -X PUT "$api"
+            -f message="inventory from ${repo_name}@${GITHUB_SHA::7}"
+            -f content="$(base64 -w0 /tmp/objects.inv)"
+          )
+          if [[ -n "$sha" ]]; then
+            payload+=(-f sha="$sha")
+          fi
+          gh api "${payload[@]}"

--- a/.github/workflows/publish-inventory.yml
+++ b/.github/workflows/publish-inventory.yml
@@ -46,6 +46,7 @@ jobs:
           fetch-tags: true
 
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
@@ -58,6 +59,12 @@ jobs:
 
       - name: Install dynamic versioning plugin
         run: poetry self add "poetry-dynamic-versioning[plugin]>=1.0.0,<2.0.0"
+
+      - name: Load cached venv
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-inventory-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
 
       - name: Install dependencies
         run: poetry install ${{ inputs.poetry-install-args }}

--- a/src/mkdocs_terok/inventory.py
+++ b/src/mkdocs_terok/inventory.py
@@ -55,21 +55,24 @@ def build_inventory(*, config: Path, output: Path) -> None:
     """Generate ``objects.inv`` for the project at *config*.
 
     Loads *config* as text, removes sibling-terok inventory list entries,
-    writes the patched config to a scratch directory, runs ``properdocs
-    build --no-strict`` into that scratch ``site/`` directory, then copies
+    writes the patched config alongside the original, runs ``properdocs
+    build --no-strict`` into a scratch ``site/`` directory, then copies
     ``site/objects.inv`` to *output*.
 
-    Raises [`SystemExit`][] non-zero if the build fails or the inventory
-    file is not produced.
+    Raises:
+        subprocess.CalledProcessError: the underlying ``properdocs build``
+            failed.  The exception's ``returncode`` carries the exit code.
+        FileNotFoundError: the build completed but no ``objects.inv`` was
+            produced (a ProperDocs configuration bug rather than a build
+            failure).
     """
     patched_text = _strip_sibling_inventory_lines(config.read_text())
 
     # ProperDocs resolves ``docs_dir`` and other relative paths against the
-    # config file's *location*, so the patched copy must live next to the
-    # original — a remote tmpdir would break ``docs/``, ``mkdocs_terok``
-    # script paths, etc.  Use ``NamedTemporaryFile`` with ``delete=False``
-    # so the path is unique (no clash with concurrent builds) and clean up
-    # explicitly via try/finally.
+    # config file's location, so the patched copy must live next to the
+    # original — a remote tmpdir would break ``docs/``, asset paths, etc.
+    # ``NamedTemporaryFile(delete=False)`` plus explicit unlink avoids the
+    # close-time delete that would race the subprocess.
     config_dir = config.parent.resolve()
     with tempfile.NamedTemporaryFile(
         mode="w",
@@ -84,7 +87,7 @@ def build_inventory(*, config: Path, output: Path) -> None:
     try:
         with tempfile.TemporaryDirectory(prefix="mkdocs-terok-inventory-") as tmp:
             site_dir = Path(tmp) / "site"
-            result = subprocess.run(
+            subprocess.run(
                 [
                     "properdocs",
                     "build",
@@ -94,23 +97,11 @@ def build_inventory(*, config: Path, output: Path) -> None:
                     "--site-dir",
                     str(site_dir),
                 ],
-                check=False,
+                check=True,
             )
-            if result.returncode != 0:
-                print(
-                    f"properdocs build failed with exit code {result.returncode}",
-                    file=sys.stderr,
-                )
-                sys.exit(result.returncode)
-
             produced = site_dir / "objects.inv"
             if not produced.is_file():
-                print(
-                    f"objects.inv was not produced at {produced}",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-
+                raise FileNotFoundError(f"objects.inv was not produced at {produced}")
             output.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(produced, output)
     finally:
@@ -152,7 +143,13 @@ def _main(argv: list[str] | None = None) -> None:
         help="Where to write the generated inventory (default: ./objects.inv)",
     )
     args = parser.parse_args(argv)
-    build_inventory(config=args.config, output=args.output)
+    try:
+        build_inventory(config=args.config, output=args.output)
+    except subprocess.CalledProcessError as exc:
+        sys.exit(exc.returncode)
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/mkdocs_terok/inventory.py
+++ b/src/mkdocs_terok/inventory.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: 0BSD
+
+"""Sibling-decoupled ``objects.inv`` builder for terok-* repos.
+
+Each terok repo's docs build references symbols from its siblings via
+mkdocstrings ``inventories:`` URLs.  When every repo's strict build needs
+every other repo's inventory, a brand-new repo (or a sibling whose Pages
+deploy is mid-rebuild) breaks the cycle for everybody.
+
+This module produces a ``objects.inv`` for the *current* repo without
+needing any sibling's inventory to exist: it loads the project's
+``properdocs.yml``, drops every inventory URL pointing at another
+``terok-*`` artifact, then runs a non-strict ``properdocs build`` into a
+scratch directory and copies the resulting ``site/objects.inv`` to the
+caller's chosen output path.
+
+The output is published independently of the docs site (via the
+``terok-ai/docs-inventories`` Contents-API bucket — see
+``.github/workflows/publish-inventory.yml``), so the strict docs build of
+every repo can fetch a fresh sibling inventory regardless of where the
+sibling's own docs deploy is in its lifecycle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+#: Lines whose inventory URL matches this regex are stripped before the
+#: inventory build runs.  Both the legacy GitHub Pages location and the new
+#: ``docs-inventories`` raw URL are removed, so a brand-new repo can publish
+#: its first inventory before any sibling's bucket file exists.
+_SIBLING_INVENTORY_URL = re.compile(
+    r"https?://(?:"
+    r"terok-ai\.github\.io/(?:terok|terok-[a-z]+|mkdocs-terok)/"
+    r"|"
+    r"raw\.githubusercontent\.com/terok-ai/docs-inventories/"
+    r")"
+)
+
+#: Matches a YAML list item whose value is a sibling inventory URL,
+#: e.g. ``    - https://terok-ai.github.io/terok-sandbox/objects.inv``.
+#: Anchored on ``- `` so plain dependency-list URLs elsewhere in the
+#: file (which never start with ``- ``) are left untouched.
+_INVENTORY_LINE = re.compile(rf"^\s*-\s+{_SIBLING_INVENTORY_URL.pattern}\S*\s*$")
+
+
+def build_inventory(*, config: Path, output: Path) -> None:
+    """Generate ``objects.inv`` for the project at *config*.
+
+    Loads *config* as text, removes sibling-terok inventory list entries,
+    writes the patched config to a scratch directory, runs ``properdocs
+    build --no-strict`` into that scratch ``site/`` directory, then copies
+    ``site/objects.inv`` to *output*.
+
+    Raises [`SystemExit`][] non-zero if the build fails or the inventory
+    file is not produced.
+    """
+    patched_text = _strip_sibling_inventory_lines(config.read_text())
+
+    # ProperDocs resolves ``docs_dir`` and other relative paths against the
+    # config file's *location*, so the patched copy must live next to the
+    # original — a remote tmpdir would break ``docs/``, ``mkdocs_terok``
+    # script paths, etc.  Use ``NamedTemporaryFile`` with ``delete=False``
+    # so the path is unique (no clash with concurrent builds) and clean up
+    # explicitly via try/finally.
+    config_dir = config.parent.resolve()
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        prefix=".inventory-",
+        suffix=".yml",
+        dir=config_dir,
+        delete=False,
+    ) as patched_file:
+        patched_file.write(patched_text)
+        patched_path = Path(patched_file.name)
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="mkdocs-terok-inventory-") as tmp:
+            site_dir = Path(tmp) / "site"
+            result = subprocess.run(
+                [
+                    "properdocs",
+                    "build",
+                    "--no-strict",
+                    "--config-file",
+                    str(patched_path),
+                    "--site-dir",
+                    str(site_dir),
+                ],
+                check=False,
+            )
+            if result.returncode != 0:
+                print(
+                    f"properdocs build failed with exit code {result.returncode}",
+                    file=sys.stderr,
+                )
+                sys.exit(result.returncode)
+
+            produced = site_dir / "objects.inv"
+            if not produced.is_file():
+                print(
+                    f"objects.inv was not produced at {produced}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+            output.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(produced, output)
+    finally:
+        patched_path.unlink(missing_ok=True)
+
+
+def _strip_sibling_inventory_lines(text: str) -> str:
+    """Return *text* with sibling-terok inventory list lines removed.
+
+    Operates on the raw YAML text rather than parsing+re-emitting because
+    ProperDocs configs use ``!!python/name:`` tags which round-trip
+    poorly through PyYAML's safe loader/dumper pair.  Sibling inventory
+    entries always live on their own list-item line, so a line-based
+    filter is sufficient and keeps every other line byte-for-byte.
+    """
+    return "\n".join(line for line in text.splitlines() if not _INVENTORY_LINE.match(line)) + (
+        "\n" if text.endswith("\n") else ""
+    )
+
+
+def _main(argv: list[str] | None = None) -> None:
+    """``python -m mkdocs_terok.inventory`` entrypoint."""
+    parser = argparse.ArgumentParser(
+        prog="python -m mkdocs_terok.inventory",
+        description="Build a sibling-decoupled objects.inv for a terok-* repo.",
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=Path,
+        default=Path("properdocs.yml"),
+        help="Path to the project's ProperDocs config (default: properdocs.yml)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("objects.inv"),
+        help="Where to write the generated inventory (default: ./objects.inv)",
+    )
+    args = parser.parse_args(argv)
+    build_inventory(config=args.config, output=args.output)
+
+
+if __name__ == "__main__":
+    _main()

--- a/tach.toml
+++ b/tach.toml
@@ -37,6 +37,8 @@ expose = [
   "config_reference.render_model_tables",
   "config_reference.render_yaml_example",
   "config_reference.render_json_schema",
+  "inventory",
+  "inventory.build_inventory",
 ]
 
 [[interfaces]]

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -5,9 +5,18 @@
 
 from __future__ import annotations
 
+import subprocess
 import textwrap
+from collections.abc import Callable
+from pathlib import Path
 
-from mkdocs_terok.inventory import _strip_sibling_inventory_lines
+import pytest
+
+from mkdocs_terok.inventory import (
+    _main,
+    _strip_sibling_inventory_lines,
+    build_inventory,
+)
 
 
 class TestStripSiblingInventoryLines:
@@ -83,3 +92,164 @@ class TestStripSiblingInventoryLines:
         """)
         out = _strip_sibling_inventory_lines(text)
         assert "terok-ai.github.io" not in out
+
+
+class _FakeProperdocs:
+    """Minimal ``subprocess.run`` double standing in for ``properdocs build``.
+
+    Captures the patched ``--config-file`` text the orchestrator wrote (so
+    tests can assert on the strip), and lets each scenario decide whether
+    to write ``site/objects.inv`` and what return code to fake.
+    """
+
+    def __init__(
+        self,
+        *,
+        write_inventory: bool = True,
+        inventory_bytes: bytes = b"OBJECTS_INV_DATA",
+        on_run: Callable[[list[str]], None] | None = None,
+    ) -> None:
+        self.write_inventory = write_inventory
+        self.inventory_bytes = inventory_bytes
+        self.on_run = on_run
+        self.captured_config_text: str | None = None
+        self.last_cmd: list[str] | None = None
+
+    def __call__(self, cmd: list[str], **_: object) -> subprocess.CompletedProcess:
+        self.last_cmd = cmd
+        cfg_path = Path(cmd[cmd.index("--config-file") + 1])
+        self.captured_config_text = cfg_path.read_text()
+        site_dir = Path(cmd[cmd.index("--site-dir") + 1])
+        site_dir.mkdir(parents=True, exist_ok=True)
+        if self.write_inventory:
+            (site_dir / "objects.inv").write_bytes(self.inventory_bytes)
+        if self.on_run is not None:
+            self.on_run(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+
+def _make_config(tmp_path: Path, body: str = "site_name: x\n") -> Path:
+    """Write *body* to ``tmp_path/properdocs.yml`` and return the path."""
+    cfg = tmp_path / "properdocs.yml"
+    cfg.write_text(body)
+    return cfg
+
+
+class TestBuildInventory:
+    """Verify the orchestration around the ``properdocs build`` subprocess."""
+
+    def test_happy_path_copies_inventory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Successful build copies ``site/objects.inv`` to the requested output."""
+        cfg = _make_config(tmp_path)
+        out = tmp_path / "out" / "objects.inv"
+        fake = _FakeProperdocs()
+        monkeypatch.setattr(subprocess, "run", fake)
+
+        build_inventory(config=cfg, output=out)
+
+        assert out.read_bytes() == b"OBJECTS_INV_DATA"
+        # Patched config is cleaned up regardless of success.
+        assert not list(tmp_path.glob(".inventory-*.yml"))
+
+    def test_strips_sibling_urls_from_patched_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The config handed to ``properdocs build`` has sibling URLs removed."""
+        cfg = _make_config(
+            tmp_path,
+            body=textwrap.dedent("""\
+                inventories:
+                  - https://terok-ai.github.io/terok-sandbox/objects.inv
+                  - https://docs.python.org/3/objects.inv
+            """),
+        )
+        fake = _FakeProperdocs()
+        monkeypatch.setattr(subprocess, "run", fake)
+
+        build_inventory(config=cfg, output=tmp_path / "objects.inv")
+
+        assert fake.captured_config_text is not None
+        assert "terok-ai.github.io" not in fake.captured_config_text
+        assert "docs.python.org" in fake.captured_config_text
+
+    def test_subprocess_failure_propagates_and_cleans_up(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``CalledProcessError`` propagates; the patched config is still removed."""
+        cfg = _make_config(tmp_path)
+
+        def fake_run(cmd: list[str], **_: object) -> subprocess.CompletedProcess:
+            raise subprocess.CalledProcessError(7, cmd)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        with pytest.raises(subprocess.CalledProcessError) as exc:
+            build_inventory(config=cfg, output=tmp_path / "objects.inv")
+
+        assert exc.value.returncode == 7
+        assert not list(tmp_path.glob(".inventory-*.yml"))
+
+    def test_missing_objects_inv_raises_file_not_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A successful build that doesn't emit ``objects.inv`` raises clearly."""
+        cfg = _make_config(tmp_path)
+        monkeypatch.setattr(subprocess, "run", _FakeProperdocs(write_inventory=False))
+
+        with pytest.raises(FileNotFoundError, match="objects.inv was not produced"):
+            build_inventory(config=cfg, output=tmp_path / "objects.inv")
+
+    def test_creates_output_parent_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nested output paths get their parents created on the fly."""
+        cfg = _make_config(tmp_path)
+        out = tmp_path / "deep" / "nested" / "objects.inv"
+        monkeypatch.setattr(subprocess, "run", _FakeProperdocs())
+
+        build_inventory(config=cfg, output=out)
+
+        assert out.is_file()
+
+
+class TestMain:
+    """Verify the ``python -m mkdocs_terok.inventory`` exit-code translation."""
+
+    def test_success_exits_cleanly(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A clean run returns from ``_main`` without raising ``SystemExit``."""
+        cfg = _make_config(tmp_path)
+        out = tmp_path / "objects.inv"
+        monkeypatch.setattr(subprocess, "run", _FakeProperdocs())
+
+        _main(["-c", str(cfg), "-o", str(out)])
+
+        assert out.is_file()
+
+    def test_subprocess_failure_exits_with_returncode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CalledProcessError → ``sys.exit(returncode)`` so CI sees the original code."""
+        cfg = _make_config(tmp_path)
+
+        def fake_run(cmd: list[str], **_: object) -> subprocess.CompletedProcess:
+            raise subprocess.CalledProcessError(42, cmd)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        with pytest.raises(SystemExit) as exc:
+            _main(["-c", str(cfg), "-o", str(tmp_path / "objects.inv")])
+
+        assert exc.value.code == 42
+
+    def test_missing_inventory_exits_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """FileNotFoundError → ``sys.exit(1)`` and the message goes to stderr."""
+        cfg = _make_config(tmp_path)
+        monkeypatch.setattr(subprocess, "run", _FakeProperdocs(write_inventory=False))
+
+        with pytest.raises(SystemExit) as exc:
+            _main(["-c", str(cfg), "-o", str(tmp_path / "objects.inv")])
+
+        assert exc.value.code == 1
+        assert "objects.inv was not produced" in capsys.readouterr().err

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: 0BSD
+
+"""Tests for the sibling-decoupled inventory builder."""
+
+from __future__ import annotations
+
+import textwrap
+
+from mkdocs_terok.inventory import _strip_sibling_inventory_lines
+
+
+class TestStripSiblingInventoryLines:
+    """Verify the textual stripper drops only sibling-terok inventory list items."""
+
+    def test_strips_legacy_pages_urls(self) -> None:
+        """``terok-ai.github.io/<repo>/objects.inv`` lines disappear."""
+        text = textwrap.dedent("""\
+            inventories:
+              - https://docs.python.org/3/objects.inv
+              - https://terok-ai.github.io/terok/objects.inv
+              - https://terok-ai.github.io/terok-sandbox/objects.inv
+              - https://terok-ai.github.io/mkdocs-terok/objects.inv
+        """)
+        out = _strip_sibling_inventory_lines(text)
+        assert "docs.python.org" in out
+        assert "terok-ai.github.io" not in out
+
+    def test_strips_new_bucket_urls(self) -> None:
+        """``raw.githubusercontent.com/terok-ai/docs-inventories/...`` lines disappear."""
+        text = textwrap.dedent("""\
+            inventories:
+              - https://raw.githubusercontent.com/terok-ai/docs-inventories/main/terok/objects.inv
+              - https://docs.pydantic.dev/latest/objects.inv
+        """)
+        out = _strip_sibling_inventory_lines(text)
+        assert "docs-inventories" not in out
+        assert "pydantic" in out
+
+    def test_preserves_non_sibling_urls(self) -> None:
+        """Stdlib + third-party inventories survive the strip."""
+        text = textwrap.dedent("""\
+            inventories:
+              - https://docs.python.org/3/objects.inv
+              - https://docs.pydantic.dev/latest/objects.inv
+              - https://example.com/things/objects.inv
+        """)
+        assert _strip_sibling_inventory_lines(text) == text
+
+    def test_does_not_match_dependency_pin_urls(self) -> None:
+        """Wheel pins under ``terok-ai.github.io/.../releases/...`` are not list items.
+
+        ``pyproject.toml`` references like
+        ``url = "https://github.com/.../wheel.whl"`` never start with the YAML
+        ``- `` list marker, so the line filter must leave them untouched even
+        when they contain ``terok-ai`` substrings.
+        """
+        text = textwrap.dedent("""\
+            terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.115/terok_sandbox-0.0.115-py3-none-any.whl"}
+            terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.140/terok_executor-0.0.140-py3-none-any.whl"}
+        """)
+        assert _strip_sibling_inventory_lines(text) == text
+
+    def test_preserves_trailing_newline(self) -> None:
+        """A trailing newline survives the round-trip (mkdocs is fussy)."""
+        text = "key: value\n"
+        assert _strip_sibling_inventory_lines(text).endswith("\n")
+
+    def test_handles_no_trailing_newline(self) -> None:
+        """No trailing newline in → none out (don't manufacture whitespace)."""
+        text = "key: value"
+        assert not _strip_sibling_inventory_lines(text).endswith("\n")
+
+    def test_strips_with_indentation_variants(self) -> None:
+        """Various leading-whitespace amounts are all matched."""
+        text = textwrap.dedent("""\
+            handlers:
+              python:
+                inventories:
+                            - https://terok-ai.github.io/terok-shield/objects.inv
+                  - https://terok-ai.github.io/terok-clearance/objects.inv
+            -    https://terok-ai.github.io/terok-executor/objects.inv
+        """)
+        out = _strip_sibling_inventory_lines(text)
+        assert "terok-ai.github.io" not in out


### PR DESCRIPTION
## Summary

Adds shared infrastructure to break the cross-repo `--strict` docs-build cycle that has bitten every terok-* repo whenever a sibling's Pages deploy lags or fails (e.g. terok-ai/terok-executor#XXX, the recurring `Couldn't load inventory https://terok-ai.github.io/<sibling>/objects.inv` failure).

- New `mkdocs_terok.inventory` module + `python -m mkdocs_terok.inventory` CLI: strips sibling-terok inventory URLs from `properdocs.yml`, runs a non-strict `properdocs build` to a scratch dir, copies out `site/objects.inv`. Output depends only on this repo.
- New reusable workflow `.github/workflows/publish-inventory.yml`: invoked by each terok-* repo's `inventory.yml`. Builds the inventory and PUTs it to `terok-ai/docs-inventories` via the Contents API. Bucket layout: `<repo>/objects.inv` per source repo.
- New consumer-side workflow `.github/workflows/inventory.yml` wires *this* repo into the system on every master push.

## Why

Today every repo's strict docs build needs every sibling's `objects.inv` published at `terok-ai.github.io/<sibling>/objects.inv`. That URL only exists once that sibling's Pages deploy finishes successfully — which itself needs *this* repo's inventory. Symmetric chicken-and-egg, breaks on every Pages flake.

The new bucket repo (`terok-ai/docs-inventories`, populated via Contents-API PUTs) holds inventories independently of any docs deploy. Each repo's `properdocs.yml` will swap its sibling URLs from `terok-ai.github.io/...` to `raw.githubusercontent.com/terok-ai/docs-inventories/main/<sibling>/objects.inv` — sibling-independent, no Pages dependency.

## Bucket setup (manual, one time, by maintainer)

Before any consumer adopts:

1. Create empty repo `terok-ai/docs-inventories` (public, no Pages, no description needed).
2. Mint a fine-grained PAT scoped to that single repo with `Contents: write`.
3. Add it as an **org-level** secret named `INVENTORY_WRITE_TOKEN` so every terok-* repo's workflows can read it.

After that, each terok-* repo just adopts the consumer template (`inventory.yml`) — no per-repo secret setup.

## Test plan

- [x] Unit: `tests/test_inventory.py` covers URL stripping (legacy Pages, new bucket, third-party preservation, dependency-pin URLs left untouched, indentation variants, trailing-newline preservation)
- [x] Smoke: ran on this repo (`mkdocs-terok`) — produced 38-symbol `objects.inv`
- [x] Smoke: ran on `terok-executor` (the canonical "needs sibling inventories" case) — produced 944-symbol `objects.inv` despite stripping all sibling URLs; cross-ref warnings to `terok_sandbox.*` are expected and tolerated
- [x] Static: ruff, ruff format, tach, docstr-coverage 100%, vulture, REUSE — all green
- [ ] End-to-end (after merge + bucket setup + first run of `inventory.yml`): confirm `https://raw.githubusercontent.com/terok-ai/docs-inventories/main/mkdocs-terok/objects.inv` resolves

## Rollout (separate PRs per repo, after this merges + bucket is set up)

terok, terok-executor, terok-sandbox, terok-shield, terok-clearance — each gets:
- `.github/workflows/inventory.yml` calling the reusable workflow
- `properdocs.yml` URL swap for sibling inventories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New tool for generating documentation inventory files compatible with documentation systems
  * Automated inventory publishing workflow triggered on every commit to the master branch

* **Tests**
  * Added test coverage for inventory generation functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/mkdocs-terok/pull/58)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->