### PR TITLE
fix(inventory): grant contents: read so the reusable call validates

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -13,7 +13,12 @@ on:
     branches: [master]
   workflow_dispatch:
 
-permissions: {}
+# `contents: read` here is required so the called reusable workflow can
+# request the same — GitHub Actions rejects a called workflow that asks
+# for permissions outside the caller's grant, which manifests as
+# ``startup_failure`` with no jobs spawned.
+permissions:
+  contents: read
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary

The `inventory.yml` caller had `permissions: {}` while the `publish-inventory.yml` reusable workflow it invokes asks for `contents: read` at the job level (for `actions/checkout@v6`).

GitHub Actions rejects a called workflow whose permission requests aren't a subset of the caller's grant. Net result on master: every `Publish inventory` run since the merge has been `startup_failure` with **zero jobs spawned**, leaving the `terok-ai/docs-inventories` bucket empty and breaking `properdocs build --strict` everywhere.

This grants `contents: read` at the workflow level — the minimum that satisfies the reusable workflow's `checkout` step. The Contents-API `PUT` in the publish step uses `INVENTORY_WRITE_TOKEN`, not `GITHUB_TOKEN`, so no further permissions are needed.

## Why startup_failure with no diagnostic

When the called workflow's permissions exceed the caller's, GitHub fails the run at validation time *before* spawning any check runs — which is why `gh run view` shows "This run likely failed because of a workflow file issue." with no useful detail.

## Rollout

This fixes mkdocs-terok itself. Each of the 5 consumer repos (terok, terok-executor, terok-sandbox, terok-shield, terok-clearance) needs the identical one-line change pushed to its master since they were all rolled out from the same broken template. Companion PRs follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/mkdocs-terok/pull/60)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->