### PR TITLE
fix(inventory): default to --only main,docs to skip dev/test groups

### DIFF
--- a/.github/workflows/publish-inventory.yml
+++ b/.github/workflows/publish-inventory.yml
@@ -20,9 +20,9 @@ on:
         type: string
         default: "3.12"
       poetry-install-args:
-        description: "Extra args passed to ``poetry install``"
+        description: "Args passed to ``poetry install``.  Default uses ``--only`` to skip dev/test groups, which often pull system-dep'd build-from-source packages (``python-dbusmock`` → ``dbus-python``, etc.) that aren't needed for inventory generation."
         type: string
-        default: "--with docs --no-interaction"
+        default: "--only main,docs --no-interaction"
       bucket-repo:
         description: "Owner/name of the inventory bucket repo"
         type: string


### PR DESCRIPTION
## Summary

Change the default `poetry-install-args` in the reusable workflow from `--with docs --no-interaction` to `--only main,docs --no-interaction`.

## Why

`--with docs` is **additive** — it doesn't exclude the dev or test groups. Some consumer repos have test-group deps that pull build-from-source packages requiring system headers, and the runner doesn't have those headers preinstalled:

- terok-clearance → `python-dbusmock` (test) → `dbus-python` → needs `libdbus-1-dev`/meson/C compilers

This bit on terok-clearance master after merging #104 — Install dependencies failed with a meson error trying to compile dbus-python.

`--only main,docs` is precisely what inventory generation needs: the project's runtime imports (so mkdocstrings can resolve autorefs) plus `properdocs` (in the docs group). Dev/test deps aren't useful here and bring system-dep liability.

## Verified locally

On a fresh venv in terok-clearance:

```text
$ poetry install --only main,docs --no-interaction
...
Installing the current project: terok-clearance (0.6.10)
$ poetry run pip list | grep -i dbus
dbus-fast                  4.0.4    # pure Python, no system deps ✓
                                    # dbus-python correctly absent ✓

$ poetry run python -m mkdocs_terok.inventory -o /tmp/clearance-inv.inv
...
project=terok-clearance count=340
```

## Rollout

After merge + a new alpha release, every consumer's `inventory.yml` `uses:` ref needs to bump to the new tag. (The pre-existing open consumer fix-PRs at v0.5.7a2 will be re-bumped to whatever the next tag is.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to optimize Poetry dependency installation during the build process, reducing unnecessary system dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/mkdocs-terok/pull/62)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->