### PR TITLE
fix(inventory): skip heavy generators via INVENTORY_ONLY_ENV kill switch

### DIFF
--- a/src/mkdocs_terok/__init__.py
+++ b/src/mkdocs_terok/__init__.py
@@ -16,6 +16,17 @@ from pathlib import Path
 __version__ = "0.0.0"  # managed by poetry-dynamic-versioning
 
 
+#: Env var honored by [`TerokPlugin.on_files`][mkdocs_terok.plugin.TerokPlugin.on_files]
+#: to skip every generator that ``objects.inv`` doesn't depend on
+#: (``ci_map``, ``quality_report``, ``test_map``, ``module_map``).
+#: Set by [`mkdocs_terok.inventory.build_inventory`][] when subprocessing
+#: ``properdocs build`` so a minimal ``poetry install --only main,docs``
+#: env doesn't trip generators that need ``pytest``/``scc``/``vulture``.
+#: Lives at the package root so both the plugin and the inventory builder
+#: can read the same constant without crossing tach module boundaries.
+INVENTORY_ONLY_ENV = "MKDOCS_TEROK_INVENTORY_ONLY"
+
+
 def brand_css_path() -> Path:
     """Return the filesystem path to the shared brand CSS file."""
     return Path(__file__).parent / "_assets" / "extra.css"

--- a/src/mkdocs_terok/__init__.py
+++ b/src/mkdocs_terok/__init__.py
@@ -16,15 +16,15 @@ from pathlib import Path
 __version__ = "0.0.0"  # managed by poetry-dynamic-versioning
 
 
-#: Env var honored by [`TerokPlugin.on_files`][mkdocs_terok.plugin.TerokPlugin.on_files]
-#: to skip every generator that ``objects.inv`` doesn't depend on
-#: (``ci_map``, ``quality_report``, ``test_map``, ``module_map``).
-#: Set by [`mkdocs_terok.inventory.build_inventory`][] when subprocessing
-#: ``properdocs build`` so a minimal ``poetry install --only main,docs``
-#: env doesn't trip generators that need ``pytest``/``scc``/``vulture``.
-#: Lives at the package root so both the plugin and the inventory builder
-#: can read the same constant without crossing tach module boundaries.
-INVENTORY_ONLY_ENV = "MKDOCS_TEROK_INVENTORY_ONLY"
+INVENTORY_ONLY_ENV: str = "MKDOCS_TEROK_INVENTORY_ONLY"
+"""Env var honored by [`TerokPlugin.on_files`][mkdocs_terok.plugin.TerokPlugin.on_files]
+to skip every generator that ``objects.inv`` doesn't depend on
+(``ci_map``, ``quality_report``, ``test_map``, ``module_map``).
+Set by [`mkdocs_terok.inventory.build_inventory`][] when subprocessing
+``properdocs build`` so a minimal ``poetry install --only main,docs``
+env doesn't trip generators that need ``pytest``/``scc``/``vulture``.
+Lives at the package root so both the plugin and the inventory builder
+can read the same constant without crossing tach module boundaries."""
 
 
 def brand_css_path() -> Path:

--- a/src/mkdocs_terok/inventory.py
+++ b/src/mkdocs_terok/inventory.py
@@ -25,12 +25,15 @@ sibling's own docs deploy is in its lifecycle.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import shutil
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+
+from mkdocs_terok import INVENTORY_ONLY_ENV
 
 #: Lines whose inventory URL matches this regex are stripped before the
 #: inventory build runs.  Both the legacy GitHub Pages location and the new
@@ -84,6 +87,12 @@ def build_inventory(*, config: Path, output: Path) -> None:
         patched_file.write(patched_text)
         patched_path = Path(patched_file.name)
 
+    # The terok plugin honors INVENTORY_ONLY_ENV to skip generators that
+    # don't feed objects.inv (test_map needs pytest, quality_report needs
+    # scc/vulture, …) — so a ``poetry install --only main,docs`` env can
+    # still produce an inventory.
+    env = {**os.environ, INVENTORY_ONLY_ENV: "1"}
+
     try:
         with tempfile.TemporaryDirectory(prefix="mkdocs-terok-inventory-") as tmp:
             site_dir = Path(tmp) / "site"
@@ -98,6 +107,7 @@ def build_inventory(*, config: Path, output: Path) -> None:
                     str(site_dir),
                 ],
                 check=True,
+                env=env,
             )
             produced = site_dir / "objects.inv"
             if not produced.is_file():

--- a/src/mkdocs_terok/plugin.py
+++ b/src/mkdocs_terok/plugin.py
@@ -100,7 +100,7 @@ class TerokPlugin(BasePlugin[TerokPluginConfig]):
     def on_files(self, files: Files, /, *, config: ProperDocsConfig) -> Files:
         """Generate virtual files for each enabled generator.
 
-        When [`INVENTORY_ONLY_ENV`][mkdocs_terok.plugin.INVENTORY_ONLY_ENV]
+        When [`INVENTORY_ONLY_ENV`][mkdocs_terok.INVENTORY_ONLY_ENV]
         is set, the four generators that don't feed ``objects.inv``
         (``ci_map``, ``quality_report``, ``test_map``, ``module_map``)
         are skipped, so a stripped-down ``poetry install --only main,docs``

--- a/src/mkdocs_terok/plugin.py
+++ b/src/mkdocs_terok/plugin.py
@@ -12,6 +12,7 @@ Asset injection (CSS / JS) is handled automatically via ``on_config``.
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path, PurePosixPath
 
 from properdocs.config import config_options as c
@@ -20,7 +21,7 @@ from properdocs.config.defaults import ProperDocsConfig
 from properdocs.plugins import BasePlugin
 from properdocs.structure.files import File, Files
 
-from mkdocs_terok import brand_css_path, mermaid_zoom_js_path
+from mkdocs_terok import INVENTORY_ONLY_ENV, brand_css_path, mermaid_zoom_js_path
 
 log = logging.getLogger(f"properdocs.plugins.{__name__}")
 _LOG_GENERATED = "Generated %s"
@@ -97,7 +98,17 @@ class TerokPlugin(BasePlugin[TerokPluginConfig]):
         return config
 
     def on_files(self, files: Files, /, *, config: ProperDocsConfig) -> Files:
-        """Generate virtual files for each enabled generator."""
+        """Generate virtual files for each enabled generator.
+
+        When [`INVENTORY_ONLY_ENV`][mkdocs_terok.plugin.INVENTORY_ONLY_ENV]
+        is set, the four generators that don't feed ``objects.inv``
+        (``ci_map``, ``quality_report``, ``test_map``, ``module_map``)
+        are skipped, so a stripped-down ``poetry install --only main,docs``
+        environment can still produce the inventory without ``pytest``,
+        ``scc``, ``vulture``, etc. on PATH.  ``ref_pages`` always runs
+        (when enabled in user config) because every inventory entry
+        comes from an mkdocstrings render of those pages.
+        """
         if self.config.inject_css:
             files.append(
                 File.generated(config, "_assets/extra.css", abs_src_path=str(brand_css_path()))
@@ -109,14 +120,18 @@ class TerokPlugin(BasePlugin[TerokPluginConfig]):
                 )
             )
 
-        if self.config.ci_map:
-            self._generate_ci_map(files, config)
-        if self.config.quality_report:
-            self._generate_quality_report(files, config)
-        if self.config.test_map:
-            self._generate_test_map(files, config)
-        if self.config.module_map:
-            self._generate_module_map(files, config)
+        inventory_only = os.environ.get(INVENTORY_ONLY_ENV) == "1"
+
+        if not inventory_only:
+            if self.config.ci_map:
+                self._generate_ci_map(files, config)
+            if self.config.quality_report:
+                self._generate_quality_report(files, config)
+            if self.config.test_map:
+                self._generate_test_map(files, config)
+            if self.config.module_map:
+                self._generate_module_map(files, config)
+
         if self.config.ref_pages:
             self._generate_ref_pages(files, config)
 

--- a/tach.toml
+++ b/tach.toml
@@ -14,6 +14,7 @@ depends_on = [{ path = "mkdocs_terok" }]
 [[interfaces]]
 from = ["mkdocs_terok"]
 expose = [
+  "INVENTORY_ONLY_ENV",
   "brand_css_path",
   "mermaid_zoom_js_path",
   "ci_map",

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from mkdocs_terok import INVENTORY_ONLY_ENV
 from mkdocs_terok.inventory import (
     _main,
     _strip_sibling_inventory_lines,
@@ -114,9 +115,12 @@ class _FakeProperdocs:
         self.on_run = on_run
         self.captured_config_text: str | None = None
         self.last_cmd: list[str] | None = None
+        self.last_env: dict[str, str] | None = None
 
-    def __call__(self, cmd: list[str], **_: object) -> subprocess.CompletedProcess:
+    def __call__(self, cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
         self.last_cmd = cmd
+        env = kwargs.get("env")
+        self.last_env = env if isinstance(env, dict) else None
         cfg_path = Path(cmd[cmd.index("--config-file") + 1])
         self.captured_config_text = cfg_path.read_text()
         site_dir = Path(cmd[cmd.index("--site-dir") + 1])
@@ -211,6 +215,29 @@ class TestBuildInventory:
         build_inventory(config=cfg, output=out)
 
         assert out.is_file()
+
+    def test_subprocess_env_sets_inventory_only_flag(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``properdocs build`` is invoked with ``MKDOCS_TEROK_INVENTORY_ONLY=1``.
+
+        That env var is the contract that lets the ``terok`` plugin skip
+        generators which would fail in a stripped-down install (test_map
+        without pytest, quality_report without scc/vulture, …).  Without
+        it set, the inventory build trips on the first such generator.
+        """
+        cfg = _make_config(tmp_path)
+        fake = _FakeProperdocs()
+        monkeypatch.setattr(subprocess, "run", fake)
+        # Strip the env var from the parent process if a prior test left
+        # it set; the assertion below is meaningful only when the value
+        # comes from build_inventory itself.
+        monkeypatch.delenv(INVENTORY_ONLY_ENV, raising=False)
+
+        build_inventory(config=cfg, output=tmp_path / "objects.inv")
+
+        assert fake.last_env is not None
+        assert fake.last_env.get(INVENTORY_ONLY_ENV) == "1"
 
 
 class TestMain:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -284,6 +284,74 @@ class TestOnFilesRefPages:
         assert "reference/SUMMARY.md" in uris
 
 
+class TestOnFilesInventoryOnly:
+    """``MKDOCS_TEROK_INVENTORY_ONLY=1`` skips heavy generators, keeps ref_pages."""
+
+    def test_skips_heavy_generators(self, monkeypatch) -> None:
+        """ci_map, quality_report, test_map, module_map are all bypassed."""
+        from mkdocs_terok import INVENTORY_ONLY_ENV
+
+        monkeypatch.setenv(INVENTORY_ONLY_ENV, "1")
+        ci = MagicMock(return_value="# CI\n")
+        qr = MagicMock(return_value=SimpleNamespace(markdown="# QR\n", companion_files={}))
+        tm = MagicMock(return_value="# TM\n")
+        mm = MagicMock(return_value="# MM\n")
+
+        plugin = _make_plugin(
+            ci_map=True,
+            quality_report=True,
+            test_map=True,
+            module_map=True,
+            quality_report_codecov_repo="x/y",
+        )
+        _run_on_files(
+            plugin,
+            _make_config(),
+            ("mkdocs_terok.ci_map.generate_ci_map", ci),
+            ("mkdocs_terok.quality_report.generate_quality_report", qr),
+            ("mkdocs_terok.test_map.generate_test_map", tm),
+            ("mkdocs_terok.module_map.generate_module_map", mm),
+        )
+
+        ci.assert_not_called()
+        qr.assert_not_called()
+        tm.assert_not_called()
+        mm.assert_not_called()
+
+    def test_keeps_ref_pages(self, monkeypatch) -> None:
+        """ref_pages still runs in inventory mode — every objects.inv entry is sourced from those pages."""
+        from mkdocs_terok import INVENTORY_ONLY_ENV
+
+        monkeypatch.setenv(INVENTORY_ONLY_ENV, "1")
+
+        def fake_generate(cfg, *, write_file, set_edit_path):
+            write_file("reference/x/index.md", "::: x")
+            return [(("x",), "reference/x/index.md")]
+
+        uris = _run_on_files(
+            _make_plugin(ref_pages=True),
+            _make_config(),
+            ("mkdocs_terok.ref_pages.generate_ref_pages", fake_generate),
+        )
+        assert "reference/x/index.md" in uris
+
+    def test_unset_env_runs_generators_normally(self, monkeypatch) -> None:
+        """Without the env var, the plugin behaves exactly as before."""
+        from mkdocs_terok import INVENTORY_ONLY_ENV
+
+        monkeypatch.delenv(INVENTORY_ONLY_ENV, raising=False)
+        tm = MagicMock(return_value="# TM\n")
+
+        uris = _run_on_files(
+            _make_plugin(test_map=True, test_map_integration_dir="tests"),
+            _make_config(),
+            ("mkdocs_terok.test_map.generate_test_map", tm),
+        )
+
+        tm.assert_called_once()
+        assert "test-map.md" in uris
+
+
 # ---------------------------------------------------------------------------
 # _build_literate_nav
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an env-var kill switch (`MKDOCS_TEROK_INVENTORY_ONLY`) on the `terok` plugin that bypasses every generator that doesn't feed `objects.inv`. `mkdocs_terok.inventory.build_inventory` sets it when subprocessing.

## Why

The previous a3 release flipped the install default to `--only main,docs` to dodge the `dbus-python` build. That worked for clearance, but exposed the next layer: shield and terok master both broke at "Generate inventory" because the plugin's `test_map` generator runs `pytest --collect-only` — and pytest is in the test group we just stopped installing.

Same shape for `quality_report` (needs `scc`/`vulture`/`complexipy` binaries) and any future generator that shells out to dev tooling. Installing more groups isn't the answer — every group has its own way to fail on a minimal runner. Skipping the generators that don't matter for inventory is.

## Behavior

When `MKDOCS_TEROK_INVENTORY_ONLY=1`:

| Generator        | Runs in inventory mode? | Why |
|------------------|-------------------------|-----|
| `ci_map`         | no                      | adds a markdown page, doesn't feed objects.inv |
| `quality_report` | no                      | needs scc/vulture/complexipy binaries |
| `test_map`       | no                      | needs pytest |
| `module_map`     | no                      | adds a markdown page, doesn't feed objects.inv |
| `ref_pages`      | **yes**                 | every objects.inv symbol is sourced from one of those pages |
| inject_css/js    | yes                     | free |

Docs builds outside the inventory pipeline are unchanged — the env var is unset for them.

## Module placement

`INVENTORY_ONLY_ENV` lives at the package root (`mkdocs_terok/__init__.py`), exposed in tach.toml. `mkdocs_terok.inventory` can't import from `mkdocs_terok.plugin` per the existing module boundary rules.

## Verified locally

```text
$ poetry env remove --all && poetry install --only main,docs --no-interaction
$ poetry run python -m mkdocs_terok.inventory -o /tmp/shield-inv.inv
project=terok-shield count=495   ✓

$ cd ../terok-clearance
$ poetry run python -m mkdocs_terok.inventory -o /tmp/clearance-inv.inv
project=terok-clearance count=340   ✓
```

Both repos previously failed at the test_map step. New tests cover plugin behaviour with/without the env var, and that `inventory.build_inventory` actually passes it through.

## Rollout

Cut a new alpha (v0.5.7a4?). Each consumer's `inventory.yml` `uses:` ref + the wheel pin in `pyproject.toml` will need to re-bump to the new tag — same drill as last round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* **Inventory build optimization**: Environment variable enables bypassing resource-intensive generators during inventory-only operations, resulting in faster builds and reduced system resource usage.
* **Maintained reference documentation**: Reference pages continue to generate normally during optimized inventory builds, ensuring documentation completeness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/mkdocs-terok/pull/64)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->