### PR TITLE
docs: convert Sphinx :role: cross-refs to mkdocstrings autoref form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ make check      # Run lint + test + docstrings + deadcode + reuse
 - **Line length**: 100 characters
 - **Type hints**: Use Python 3.12+ type hints
 - **Docstrings**: Required for all public functions, classes, and modules (95% min)
+- **Cross-references in docstrings**: use mkdocstrings autoref syntax `` [`Name`][module.path.Name] `` — never the Sphinx ``:class:`Name``` / ``:func:`name``` forms. Sphinx roles render as literal text on the rendered docs site (mkdocstrings doesn't process them). Prefer the explicit full path over the bare `` [`Name`][] `` autoref form: explicit paths keep `properdocs build --strict` green even when the symbol's short name isn't unique. For external symbols, use the dependency's own path (e.g. `` [`Sandbox`][terok_sandbox.Sandbox] ``, `` [`StreamReader`][asyncio.StreamReader] ``) — those resolve via the inventories listed in `properdocs.yml`.
 - **SPDX headers**: Every `.py` file must have an SPDX header
 - **No runtime dependency on the doc engine in generator modules**: Only
   `plugin.py` imports `properdocs`; each generator module produces strings and

--- a/src/mkdocs_terok/module_map.py
+++ b/src/mkdocs_terok/module_map.py
@@ -146,7 +146,7 @@ def _read_tach_config(src_root: Path) -> _TachConfig | None:
 
 
 def _parse_tach(path: Path) -> _TachConfig | None:
-    """Parse a ``tach.toml`` file into a :class:`_TachConfig`."""
+    """Parse a ``tach.toml`` file into a [`_TachConfig`][mkdocs_terok.module_map._TachConfig]."""
     try:
         import tomllib
 

--- a/src/mkdocs_terok/quality_report.py
+++ b/src/mkdocs_terok/quality_report.py
@@ -5,7 +5,7 @@
 
 Runs complexipy, vulture, tach, scc, and docstr-coverage, then assembles
 the results into a single Markdown page with a Mermaid dependency diagram.
-Returns a :class:`QualityReportResult` containing the Markdown and any
+Returns a [`QualityReportResult`][mkdocs_terok.quality_report.QualityReportResult] containing the Markdown and any
 companion files (e.g. SVGs) that the consumer should write alongside it.
 """
 
@@ -126,7 +126,7 @@ def generate_quality_report(config: QualityReportConfig | None = None) -> Qualit
         config: Report configuration. Uses defaults if ``None``.
 
     Returns:
-        A :class:`QualityReportResult` with the Markdown and companion files.
+        A [`QualityReportResult`][mkdocs_terok.quality_report.QualityReportResult] with the Markdown and companion files.
     """
     if config is None:
         config = QualityReportConfig()


### PR DESCRIPTION
## Summary

Convert every `:class:`/`:func:`/`:meth:`/`:mod:`/`:attr:` Sphinx-style cross-reference in source docstrings to mkdocstrings' `[`Name`][module.path.Name]` autoref form. mkdocstrings doesn't process Sphinx info-field roles, so the originals rendered as **literal text** on the docs site (e.g. "Public surface: :class:ACPRoster, :class:AgentRosterCache, …") instead of as links.

Also adds an AGENTS.md bullet under "Coding Standards" / "Code style" so future changes don't re-introduce the Sphinx forms.

## What changed

- All converted docstrings now produce real `<a class="autorefs autorefs-internal">` links in rendered HTML, with hover tooltips showing the target's signature.
- External symbols (asyncio, terok-sandbox, …) use the dependency's own path so they resolve via the inventories listed in `properdocs.yml`.
- A handful of imprecise docstring refs (e.g. `Sandbox.runtime.exec_stdio` → `terok_sandbox.ContainerRuntime.exec_stdio`, `acp.schema.X` demoted to plain `` `code` `` text since agent-client-protocol publishes no inventory) were corrected by hand.
- AGENTS.md gains one bullet calling out the autoref convention.

## Verification

`poetry run properdocs build --strict` passes locally with **zero autoref warnings** in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)