### PR TITLE
ci: lint that README install snippet stays in sync with pyproject version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           args: format --check
 
+      # Stdlib-only (tomllib + re); ubuntu-latest's stock python3 is 3.12+,
+      # tomllib is stdlib since 3.11 — no setup-python step needed.
+      - name: README install snippet ↔ pyproject version
+        run: python3 scripts/check-readme-version.py
+
   docstring-coverage:
     if: github.repository == 'terok-ai/mkdocs-terok'
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all lint format test docstrings deadcode reuse check install install-dev clean spdx docs docs-serve
+.PHONY: all lint format test docstrings deadcode reuse readme-version check install install-dev clean spdx docs docs-serve
 
 REPORTS_DIR ?= reports
 COVERAGE_XML ?= $(REPORTS_DIR)/coverage.xml
@@ -35,8 +35,12 @@ reuse:
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	poetry run reuse lint
 
+# Check README's install snippet pins the right major.minor for this version
+readme-version:
+	python3 scripts/check-readme-version.py
+
 # Run all checks (equivalent to CI)
-check: lint test docstrings deadcode reuse
+check: lint test docstrings deadcode reuse readme-version
 
 # Install runtime dependencies only
 install:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add to your project's `pyproject.toml` as a docs-build dependency:
 
 ```toml
 [tool.poetry.group.docs.dependencies]
-mkdocs-terok = "^0.5"
+mkdocs-terok = "^0.6"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -23,11 +23,10 @@ gracefully to a warning admonition.
 
 ## Installation
 
-Add to your project as a docs-build dependency.  The bounds shown below
-are kept in lockstep with this package's current release by a CI lint
-(`scripts/check-readme-version.py`), so copy any of them verbatim.
+Add to your project as a docs-build dependency.
 
-**Poetry** — `pyproject.toml`:
+**Poetry** — `pyproject.toml` (canonical caret kept in sync with the
+current release by `scripts/check-readme-version.py`):
 
 ```toml
 [tool.poetry.group.docs.dependencies]
@@ -37,13 +36,13 @@ mkdocs-terok = "^0.6"
 **uv**:
 
 ```bash
-uv add --group docs "mkdocs-terok>=0.6,<0.7"
+uv add --group docs mkdocs-terok
 ```
 
 **pip**:
 
 ```bash
-pip install "mkdocs-terok>=0.6,<0.7"
+pip install mkdocs-terok
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ uv add --group docs mkdocs-terok
 mkdocs-terok = "^0.6"
 ```
 
+## Configuration
+
+Configured via the `terok` plugin in your `properdocs.yml`.  See this
+repository's own [`properdocs.yml`](properdocs.yml) for a self-documenting
+example that exercises every generator the package ships.
+
 ## License
 
 [0BSD](https://opensource.org/license/0bsd) — use freely, no strings attached.

--- a/README.md
+++ b/README.md
@@ -23,11 +23,27 @@ gracefully to a warning admonition.
 
 ## Installation
 
-Add to your project's `pyproject.toml` as a docs-build dependency:
+Add to your project as a docs-build dependency.  The bounds shown below
+are kept in lockstep with this package's current release by a CI lint
+(`scripts/check-readme-version.py`), so copy any of them verbatim.
+
+**Poetry** — `pyproject.toml`:
 
 ```toml
 [tool.poetry.group.docs.dependencies]
 mkdocs-terok = "^0.6"
+```
+
+**uv**:
+
+```bash
+uv add --group docs "mkdocs-terok>=0.6,<0.7"
+```
+
+**pip**:
+
+```bash
+pip install "mkdocs-terok>=0.6,<0.7"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ pip install mkdocs-terok
 uv add --group docs mkdocs-terok
 ```
 
-**Poetry** — `pyproject.toml` (canonical caret kept in sync with the
-current release by `scripts/check-readme-version.py`):
+**Poetry** — `pyproject.toml`:
 
 ```toml
 [tool.poetry.group.docs.dependencies]

--- a/README.md
+++ b/README.md
@@ -25,12 +25,10 @@ gracefully to a warning admonition.
 
 Add to your project as a docs-build dependency.
 
-**Poetry** — `pyproject.toml` (canonical caret kept in sync with the
-current release by `scripts/check-readme-version.py`):
+**pip**:
 
-```toml
-[tool.poetry.group.docs.dependencies]
-mkdocs-terok = "^0.6"
+```bash
+pip install mkdocs-terok
 ```
 
 **uv**:
@@ -39,10 +37,12 @@ mkdocs-terok = "^0.6"
 uv add --group docs mkdocs-terok
 ```
 
-**pip**:
+**Poetry** — `pyproject.toml` (canonical caret kept in sync with the
+current release by `scripts/check-readme-version.py`):
 
-```bash
-pip install mkdocs-terok
+```toml
+[tool.poetry.group.docs.dependencies]
+mkdocs-terok = "^0.6"
 ```
 
 ## License

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,10 @@ plugins:
 All generators default to **false** (opt-in). CSS and JS assets are injected
 automatically unless `inject_css` / `inject_js` are set to `false`.
 
+For a complete, real-world example see this repository's own
+[`properdocs.yml`](https://github.com/terok-ai/mkdocs-terok/blob/master/properdocs.yml)
+— it drives the very documentation site you are reading.
+
 ## Quick start — generator API
 
 Each module produces Markdown strings or structured results that consumers wrap
@@ -54,9 +58,14 @@ content generation only.
 ## Dogfooding
 
 This documentation site **uses mkdocs-terok on itself**. Every generator in the
-library is exercised against this very repository via the `terok` plugin.
+library is exercised against this very repository via the `terok` plugin — see
+[`properdocs.yml`](https://github.com/terok-ai/mkdocs-terok/blob/master/properdocs.yml)
+on master for the full live configuration.
 
-The [Config Reference Demo](config-reference.md) uses a Star Trek-themed Pydantic
-model to exercise all three renderers (`render_model_tables`, `render_yaml_example`,
-`render_json_schema`) — it remains as a `mkdocs-gen-files` script since it requires
-a consumer-specific Pydantic model.
+## Config Reference Demo
+
+The [Config Reference Demo](config-reference.md) uses a Pydantic model for a
+space weather monitoring station to exercise all three renderers
+(`render_model_tables`, `render_yaml_example`, `render_json_schema`) — it
+remains as a `mkdocs-gen-files` script since it requires a consumer-specific
+Pydantic model.

--- a/scripts/check-readme-version.py
+++ b/scripts/check-readme-version.py
@@ -45,7 +45,7 @@ def main() -> int:
 
     if (m["major"], m["minor"]) != (pkg_major, pkg_minor):
         print(
-            f'README install snippet pins ^{m["major"]}.{m["minor"]} but '
+            f"README install snippet pins ^{m['major']}.{m['minor']} but "
             f"pyproject declares {pkg_version}.\n"
             f'Fix: change the snippet to `mkdocs-terok = "^{pkg_major}.{pkg_minor}"`.',
             file=sys.stderr,

--- a/scripts/check-readme-version.py
+++ b/scripts/check-readme-version.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: 0BSD
+"""Lint: README install snippet's pin ↔ pyproject.toml's version.
+
+The README shows the canonical way to add ``mkdocs-terok`` as a docs-build
+dep — a ``mkdocs-terok = "^X.Y"`` Poetry caret pin.  When a new minor
+release lands, the README's caret has to move in lockstep; this script
+catches the case where ``pyproject.toml`` was bumped but the README was
+forgotten (a real foot-gun: every consumer who copies the snippet
+straight from GitHub gets the stale spec).
+
+Compares major.minor.  Pre-release suffixes (``0.5.7a5``) compare on
+their numeric major.minor only — alpha cycles within the same minor
+don't move the caret.  Exits 0 on match, 1 on drift, 2 on
+unparseable README / pyproject.
+"""
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+README = ROOT / "README.md"
+
+_PIN_RE = re.compile(r'mkdocs-terok\s*=\s*"\^(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?"')
+
+
+def main() -> int:
+    """Compare README pin against pyproject version; print + exit accordingly."""
+    pkg_version = tomllib.loads(PYPROJECT.read_text())["tool"]["poetry"]["version"]
+    pkg_major, pkg_minor = pkg_version.split(".")[:2]
+
+    m = _PIN_RE.search(README.read_text())
+    if not m:
+        print(
+            'README has no `mkdocs-terok = "^X.Y"` install snippet — '
+            "either the snippet was renamed/removed (update this lint) or "
+            "the pin format changed (this lint enforces the caret form).",
+            file=sys.stderr,
+        )
+        return 2
+
+    if (m["major"], m["minor"]) != (pkg_major, pkg_minor):
+        print(
+            f'README install snippet pins ^{m["major"]}.{m["minor"]} but '
+            f"pyproject declares {pkg_version}.\n"
+            f'Fix: change the snippet to `mkdocs-terok = "^{pkg_major}.{pkg_minor}"`.',
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"README pin in sync (^{m['major']}.{m['minor']} matches {pkg_version})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-readme-version.py
+++ b/scripts/check-readme-version.py
@@ -1,20 +1,17 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: 0BSD
-"""Lint: README install snippets stay in sync with ``pyproject.toml``'s version.
+"""Lint: README's Poetry caret pin ↔ ``pyproject.toml``'s version.
 
-The README shows three canonical ways to add ``mkdocs-terok`` as a
-docs-build dep — Poetry's caret form and PEP 440 ``>=X.Y,<X.Y+1`` bounds
-for uv / pip.  When a new minor release lands, every form has to move
-in lockstep; this script catches the case where ``pyproject.toml`` was
-bumped but the README was forgotten (a real foot-gun: every consumer
-who copies the snippet straight from GitHub gets a stale spec).
+The README shows the canonical install snippet — a Poetry caret pin
+(``mkdocs-terok = "^X.Y"``) consumers copy verbatim.  uv and pip
+examples sit alongside without version specifiers (always-latest), so
+only the caret needs lock-stepping with the package version.
 
-Compares major.minor for every recognised occurrence.  Pre-release
-suffixes (``0.5.7a5``) compare on their numeric major.minor only —
-alpha cycles within the same minor don't move the bounds.  Exits 0 on
-all-in-sync, 1 on any drift, 2 if the README contains no recognised
-snippet at all (renamed/removed; this lint needs updating).
+Compares major.minor.  Pre-release suffixes (``0.5.7a5``) compare on
+their numeric major.minor only — alpha cycles within the same minor
+don't move the caret.  Exits 0 on match, 1 on drift, 2 if the snippet
+isn't present (renamed/removed; this lint needs updating).
 """
 
 import re
@@ -26,46 +23,34 @@ ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = ROOT / "pyproject.toml"
 README = ROOT / "README.md"
 
-# Two recognised forms; both extract the lower-bound major.minor.
-#  - Poetry caret:  mkdocs-terok = "^0.6"   (optional patch suffix ignored)
-#  - PEP 440:       mkdocs-terok>=0.6       (optional ",<X.Y" ignored — only
-#                                            the lower bound is enforced; that
-#                                            is what consumers pin against)
-_PATTERNS = [
-    re.compile(r'mkdocs-terok\s*=\s*"\^(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?"'),
-    re.compile(r"mkdocs-terok>=(?P<major>\d+)\.(?P<minor>\d+)"),
-]
+_PIN_RE = re.compile(r'mkdocs-terok\s*=\s*"\^(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?"')
 
 
 def main() -> int:
-    """Compare every README occurrence against pyproject version; print + exit."""
+    """Compare README caret against pyproject version; print + exit accordingly."""
     pkg_version = tomllib.loads(PYPROJECT.read_text())["tool"]["poetry"]["version"]
     pkg_major, pkg_minor = pkg_version.split(".")[:2]
-    expected = (pkg_major, pkg_minor)
 
-    text = README.read_text()
-    matches = [m for pat in _PATTERNS for m in pat.finditer(text)]
-    if not matches:
+    m = _PIN_RE.search(README.read_text())
+    if not m:
         print(
-            "README has no recognised `mkdocs-terok` install snippet — "
-            "either the snippet was renamed/removed or its pin form changed "
-            "(this lint enforces Poetry caret and PEP 440 `>=X.Y` forms).",
+            'README has no `mkdocs-terok = "^X.Y"` Poetry caret snippet — '
+            "either the snippet was renamed/removed or the pin form changed "
+            "(this lint enforces the caret form).",
             file=sys.stderr,
         )
         return 2
 
-    drift = [m for m in matches if (m["major"], m["minor"]) != expected]
-    if drift:
-        snippets = "\n".join(f"  - {m.group(0)}" for m in drift)
+    if (m["major"], m["minor"]) != (pkg_major, pkg_minor):
         print(
-            f"README install snippet(s) out of sync with pyproject "
-            f"{pkg_version} (expected major.minor = "
-            f"{pkg_major}.{pkg_minor}):\n{snippets}",
+            f"README caret pins ^{m['major']}.{m['minor']} but pyproject "
+            f"declares {pkg_version}.\n"
+            f'Fix: change the snippet to `mkdocs-terok = "^{pkg_major}.{pkg_minor}"`.',
             file=sys.stderr,
         )
         return 1
 
-    print(f"README pins in sync ({len(matches)} occurrence(s) match {pkg_version})")
+    print(f"README caret in sync (^{m['major']}.{m['minor']} matches {pkg_version})")
     return 0
 
 

--- a/scripts/check-readme-version.py
+++ b/scripts/check-readme-version.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: 0BSD
-"""Lint: README install snippet's pin ↔ pyproject.toml's version.
+"""Lint: README install snippets stay in sync with ``pyproject.toml``'s version.
 
-The README shows the canonical way to add ``mkdocs-terok`` as a docs-build
-dep — a ``mkdocs-terok = "^X.Y"`` Poetry caret pin.  When a new minor
-release lands, the README's caret has to move in lockstep; this script
-catches the case where ``pyproject.toml`` was bumped but the README was
-forgotten (a real foot-gun: every consumer who copies the snippet
-straight from GitHub gets the stale spec).
+The README shows three canonical ways to add ``mkdocs-terok`` as a
+docs-build dep — Poetry's caret form and PEP 440 ``>=X.Y,<X.Y+1`` bounds
+for uv / pip.  When a new minor release lands, every form has to move
+in lockstep; this script catches the case where ``pyproject.toml`` was
+bumped but the README was forgotten (a real foot-gun: every consumer
+who copies the snippet straight from GitHub gets a stale spec).
 
-Compares major.minor.  Pre-release suffixes (``0.5.7a5``) compare on
-their numeric major.minor only — alpha cycles within the same minor
-don't move the caret.  Exits 0 on match, 1 on drift, 2 on
-unparseable README / pyproject.
+Compares major.minor for every recognised occurrence.  Pre-release
+suffixes (``0.5.7a5``) compare on their numeric major.minor only —
+alpha cycles within the same minor don't move the bounds.  Exits 0 on
+all-in-sync, 1 on any drift, 2 if the README contains no recognised
+snippet at all (renamed/removed; this lint needs updating).
 """
 
 import re
@@ -25,34 +26,46 @@ ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = ROOT / "pyproject.toml"
 README = ROOT / "README.md"
 
-_PIN_RE = re.compile(r'mkdocs-terok\s*=\s*"\^(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?"')
+# Two recognised forms; both extract the lower-bound major.minor.
+#  - Poetry caret:  mkdocs-terok = "^0.6"   (optional patch suffix ignored)
+#  - PEP 440:       mkdocs-terok>=0.6       (optional ",<X.Y" ignored — only
+#                                            the lower bound is enforced; that
+#                                            is what consumers pin against)
+_PATTERNS = [
+    re.compile(r'mkdocs-terok\s*=\s*"\^(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?"'),
+    re.compile(r"mkdocs-terok>=(?P<major>\d+)\.(?P<minor>\d+)"),
+]
 
 
 def main() -> int:
-    """Compare README pin against pyproject version; print + exit accordingly."""
+    """Compare every README occurrence against pyproject version; print + exit."""
     pkg_version = tomllib.loads(PYPROJECT.read_text())["tool"]["poetry"]["version"]
     pkg_major, pkg_minor = pkg_version.split(".")[:2]
+    expected = (pkg_major, pkg_minor)
 
-    m = _PIN_RE.search(README.read_text())
-    if not m:
+    text = README.read_text()
+    matches = [m for pat in _PATTERNS for m in pat.finditer(text)]
+    if not matches:
         print(
-            'README has no `mkdocs-terok = "^X.Y"` install snippet — '
-            "either the snippet was renamed/removed (update this lint) or "
-            "the pin format changed (this lint enforces the caret form).",
+            "README has no recognised `mkdocs-terok` install snippet — "
+            "either the snippet was renamed/removed or its pin form changed "
+            "(this lint enforces Poetry caret and PEP 440 `>=X.Y` forms).",
             file=sys.stderr,
         )
         return 2
 
-    if (m["major"], m["minor"]) != (pkg_major, pkg_minor):
+    drift = [m for m in matches if (m["major"], m["minor"]) != expected]
+    if drift:
+        snippets = "\n".join(f"  - {m.group(0)}" for m in drift)
         print(
-            f"README install snippet pins ^{m['major']}.{m['minor']} but "
-            f"pyproject declares {pkg_version}.\n"
-            f'Fix: change the snippet to `mkdocs-terok = "^{pkg_major}.{pkg_minor}"`.',
+            f"README install snippet(s) out of sync with pyproject "
+            f"{pkg_version} (expected major.minor = "
+            f"{pkg_major}.{pkg_minor}):\n{snippets}",
             file=sys.stderr,
         )
         return 1
 
-    print(f"README pin in sync (^{m['major']}.{m['minor']} matches {pkg_version})")
+    print(f"README pins in sync ({len(matches)} occurrence(s) match {pkg_version})")
     return 0
 
 


### PR DESCRIPTION
## Problem
The README's install snippet uses a Poetry caret pin (``mkdocs-terok = \"^X.Y\"``) that consumers copy verbatim into their own ``[tool.poetry.group.docs.dependencies]``. When a new minor release lands but the README's caret is forgotten, every fresh integration starts on a stale spec — which exactly happened with v0.6.0 (README was still pinning ``^0.5``).

## Fix
New ``scripts/check-readme-version.py`` (stdlib-only, ~50 LOC). Parses pyproject's static ``[tool.poetry].version``, parses the README's ``mkdocs-terok = \"^X.Y\"`` caret major.minor, compares.

- Exit 0: match (with confirmation print)
- Exit 1: drift (prints the offending caret + suggested fix line)
- Exit 2: README doesn't contain the recognised snippet form (lint needs updating)

Wired into:
- ``make check`` (now: ``lint test docstrings deadcode reuse readme-version``)
- ``ci.yml`` lint job (no extra runner spin-up — stock ubuntu python3)

## Drive-by
README pinned ``^0.5`` while pyproject was at ``0.6.0``. Bumped to ``^0.6``. This is the exact drift the lint would have caught at the v0.6.0 release.

## Test plan
- [x] Lint against current master state (pre-bump): fails with the expected drift message.
- [x] After bump: passes with confirmation print.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI lint check to validate the README install snippet against the package version.
  * Added a local validation target and included it in the aggregate project verification step.

* **Documentation**
  * Rewrote Installation: bumped mkdocs-terok from ^0.5 to ^0.6 and added pip and uv install examples.
  * Updated docs/demo wording and added a real-world example link.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/mkdocs-terok/pull/70)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->