### PR TITLE
ci: hand off coverage from CI to docs deploy via artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,25 @@ jobs:
       - name: Run tests
         run: make test
 
+      - name: Generate coverage JSON (treemap input)
+        # docs.yml consumes reports/coverage.json to render mkdocs-terok's
+        # own coverage treemap. `coverage json` reads the .coverage data file
+        # produced by `make test` above, so this does NOT re-run the test
+        # suite — it just serialises the existing coverage data.
+        run: poetry run coverage json -o reports/coverage.json
+
+      - name: Upload coverage artifact
+        # Consumed by docs.yml's master deploy via dawidd6/action-download-artifact.
+        # Same well-known-address contract as the sibling repos: workflow=ci.yml
+        # job=test artifact=coverage contains reports/coverage.{json,xml}.
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage
+          path: |
+            reports/coverage.xml
+            reports/coverage.json
+          retention-days: 1
+
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,17 @@
 # Pin third-party actions to full commit SHAs for supply-chain security.
 # GitHub-owned actions (actions/*) may use version tags.
+#
+# Coverage handoff contract (well-known address):
+#   workflow=ci.yml  job=test  artifact=coverage  contains reports/coverage.{json,xml}
+#
+# reports/coverage.json drives mkdocs-terok's own coverage treemap. The CI
+# workflow's test job already produces it, so this build downloads that
+# artifact instead of paying for a second pytest run. The coverage JSON
+# itself is throwaway: only the rendered SVG is published.
+#
+# This workflow is master-only (deploys to GitHub Pages); we always require
+# the same-SHA CI run to have completed successfully before pulling the
+# artifact, so the published treemap matches the published code.
 name: Docs
 
 on:
@@ -19,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -58,10 +71,54 @@ jobs:
           sudo tar -xzf /tmp/scc.tar.gz -C /usr/local/bin scc
 
       - name: Install dependencies
-        run: poetry install --with docs,test --no-interaction
+        # Dropped the `test` group: this workflow no longer runs pytest; the
+        # `coverage` artifact below carries everything the treemap needs.
+        run: poetry install --with docs --no-interaction
 
-      - name: Generate coverage data for treemap
-        run: poetry run pytest --cov=mkdocs_terok --cov-report=json:reports/coverage.json -q
+      # Wait for ci.yml's run on this commit to finish. CI is fast (no
+      # third-party services on the critical path), so this normally returns
+      # within seconds when the workflows are triggered together by a master
+      # push. Failing CI fails the docs deploy — published treemap must agree
+      # with published code.
+      - name: Wait for CI on this commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deadline = Date.now() + 20 * 60 * 1000;
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+            while (Date.now() < deadline) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'ci.yml',
+                head_sha: context.sha,
+                per_page: 5,
+              });
+              const run = data.workflow_runs[0];
+              if (run?.status === 'completed') {
+                if (run.conclusion === 'success') {
+                  core.info(`CI succeeded for ${context.sha}`);
+                  return;
+                }
+                core.setFailed(
+                  `CI ${run.conclusion} for ${context.sha} — refusing to publish docs with a mismatched treemap`
+                );
+                return;
+              }
+              core.info(`CI for ${context.sha}: ${run?.status ?? 'not yet started'} — waiting`);
+              await sleep(20_000);
+            }
+            core.setFailed('Timed out after 20m waiting for CI')
+
+      - name: Coverage artifact (same SHA, required)
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: ci.yml
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          name: coverage
+          path: reports
+          if_no_artifact_found: fail
 
       - name: Build documentation
         run: poetry run properdocs build --strict


### PR DESCRIPTION
## Summary

The master `Docs` deploy used to re-run pytest just to regenerate `reports/coverage.json` for the coverage treemap, duplicating the work the `test` job in `ci.yml` had already done on the same commit. This PR wires up an artifact handoff so `docs.yml` consumes the existing coverage data instead.

## File changes

| File | Change |
|---|---|
| `ci.yml` | Test job now (a) generates `reports/coverage.json` from the already-collected `.coverage` data via `poetry run coverage json` (no re-run), and (b) uploads `reports/coverage.{xml,json}` as the `coverage` artifact (1-day retention). |
| `docs.yml` | Replaces inline `pytest --cov` with `dawidd6/action-download-artifact`. Waits for the same-SHA `CI` run to succeed first (actions/github-script poll), then pulls the artifact. Drops the now-unused `test` dependency group from `poetry install`. |

## Contract

Matches the well-known-address shape used across the sibling repos:

> *Workflow `ci.yml`, job `test`, artifact `coverage`, contains `reports/coverage.{json,xml}`.*

## Test plan

- [ ] `ci.yml` `test` job still passes; the new "Generate coverage JSON" step takes <1s (uses already-collected data).
- [ ] `ci.yml` uploads a `coverage` artifact with both `.xml` and `.json` inside.
- [ ] After merge to master: `Docs` workflow waits briefly for the same-SHA CI run, downloads the artifact, builds the docs with a fresh treemap, and deploys to Pages.
- [ ] If CI fails on a master commit, Docs fails fast (no stale-treemap publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)