### PR TITLE
chore: migrate pyproject.toml to PEP 621 [project] table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,25 +195,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-
-      - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
-
-      - name: Install dynamic versioning plugin
-        run: poetry self add "poetry-dynamic-versioning[plugin]"
-
-      - name: Build sdist + wheel
-        run: poetry build
-
-      - name: Verify README rendering for PyPI
+      - name: Verify README renders for PyPI
         run: |
-          pip install twine
-          twine check dist/*
+          pip install 'readme_renderer[md]'
+          python -m readme_renderer README.md --format md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,3 +189,31 @@ jobs:
           name: docs-preview
           path: site/
           retention-days: 7
+
+  readme-check:
+    if: github.repository == 'terok-ai/mkdocs-terok'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
+
+      - name: Install dynamic versioning plugin
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
+
+      - name: Build sdist + wheel
+        run: poetry build
+
+      - name: Verify README rendering for PyPI
+        run: |
+          pip install twine
+          twine check dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/poetry.lock
+++ b/poetry.lock
@@ -1954,4 +1954,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "294a75b592e427d0a561c8e98c774808179f3e94bc52c7c3b41749aa49b2e7a6"
+content-hash = "25fd9389dde5eca19f45d55e4d9ff294fa58ef88fab211fa29830e99e10960a4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,20 +2,44 @@
 requires = ["poetry-core>=1.9.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
 build-backend = "poetry_dynamic_versioning.backend"
 
-[tool.poetry]
+[project]
 name = "mkdocs-terok"
-version = "0.6.0"
 description = "Shared ProperDocs documentation generators for terok projects"
 readme = "README.md"
 license = "0BSD"
-authors = ["Jiri Vyskocil <jiri@vyskocil.com>"]
+authors = [
+    {name = "Jiri Vyskocil", email = "jiri@vyskocil.com"},
+]
+maintainers = [
+    {name = "Jiri Vyskocil", email = "jiri@vyskocil.com"},
+]
 keywords = ["properdocs", "mkdocs", "documentation", "code-metrics", "ci-map"]
+requires-python = ">=3.12,<4.0"
+dynamic = ["version", "classifiers"]
+dependencies = [
+    "PyYAML>=6.0",
+    "properdocs>=1.6.7",
+    "squarify>=0.4",
+]
+
+[project.urls]
+Homepage = "https://terok.ai/"
+Repository = "https://github.com/terok-ai/mkdocs-terok"
+Documentation = "https://terok-ai.github.io/mkdocs-terok/"
+Issues = "https://github.com/terok-ai/mkdocs-terok/issues"
+Changelog = "https://github.com/terok-ai/mkdocs-terok/releases"
+Security = "https://github.com/terok-ai/mkdocs-terok/security/policy"
+
+[project.entry-points."mkdocs.plugins"]
+terok = "mkdocs_terok.plugin:TerokPlugin"
+
+[tool.poetry]
+version = "0.6.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Framework :: MkDocs",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
     "Topic :: Documentation",
@@ -30,19 +54,6 @@ include = [
   { path = "src/mkdocs_terok/_assets/*.css" },
   { path = "src/mkdocs_terok/_assets/*.js" },
 ]
-maintainers = ["Jiri Vyskocil <jiri@vyskocil.com>"]
-homepage = "https://terok.ai/"
-repository = "https://github.com/terok-ai/mkdocs-terok"
-documentation = "https://terok-ai.github.io/mkdocs-terok/"
-
-[tool.poetry.dependencies]
-python = ">=3.12,<4.0"
-PyYAML = ">=6.0"
-properdocs = ">=1.6.7"
-squarify = ">=0.4"
-
-[tool.poetry.plugins."mkdocs.plugins"]
-terok = "mkdocs_terok.plugin:TerokPlugin"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.8"
@@ -55,11 +66,6 @@ pytest = ">=7.0"
 pytest-cov = ">=4.0"
 pydantic = ">=2.6"
 
-
-[tool.poetry.urls]
-Issues = "https://github.com/terok-ai/mkdocs-terok/issues"
-Changelog = "https://github.com/terok-ai/mkdocs-terok/releases"
-Security = "https://github.com/terok-ai/mkdocs-terok/security/policy"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ Homepage = "https://terok.ai/"
 Repository = "https://github.com/terok-ai/mkdocs-terok"
 Documentation = "https://terok-ai.github.io/mkdocs-terok/"
 Issues = "https://github.com/terok-ai/mkdocs-terok/issues"
-Changelog = "https://github.com/terok-ai/mkdocs-terok/releases"
+Changelog = "https://github.com/terok-ai/mkdocs-terok/blob/master/CHANGELOG.md"
 Security = "https://github.com/terok-ai/mkdocs-terok/security/policy"
 
 [project.entry-points."mkdocs.plugins"]


### PR DESCRIPTION
## Summary

Migrate `pyproject.toml` to PEP 621 (`[project]` table).  Poetry 2.x has deprecated every static-metadata field under `[tool.poetry]` that has a PEP 621 equivalent — this clears the warning surface and moves us onto modern ecosystem standards.

## What moves to `[project]`

`name`, `description`, `readme`, `license`, `authors`, `maintainers`, `keywords`, runtime `dependencies`, `scripts`, `plugins` (→ `entry-points`), and URLs (homepage/repository/documentation/issues/changelog/security).

## What stays in `[tool.poetry]`

- `version` — `poetry-dynamic-versioning` keeps owning it; marked `dynamic = ["version"]` in `[project]`.
- `classifiers` — kept so Poetry's auto-enrichment for Python-version classifiers continues to work; marked `dynamic = ["classifiers"]` in `[project]`.
- `packages`, `include` — Poetry-specific build config.
- `[tool.poetry.group.*.dependencies]` — dev/test/docs groups; not deprecated.

## Format conversions

- URL pins: `{url = "..."}` → `"name @ <url>"` (PEP 508)
- Caret: `^X.Y` → `>=X.Y,<upper` (upper bumps the leftmost non-zero segment, matching Poetry caret semantics)
- Authors: `["Name <email>"]` → `[{name = "Name", email = "email"}]`
- `python = "..."` (in deps) → `requires-python = "..."` in `[project]`

## Deletion

Dropped the `License :: OSI Approved :: BSD License` trove classifier — PEP 639 makes `[project.license]` the source of truth and PyPI rejects new releases that still carry the classifier.

## How it was generated

[`terok-toolbox/scripts/migrate-to-pep621.py`](https://github.com/terok-warden/terok-toolbox/blob/feat/pep621-dep-rewrite/scripts/migrate-to-pep621.py) — idempotent, tomlkit-based.  Same script ran on all six siblings to keep the migration uniform.

## Test plan

- [x] `poetry check --strict` → "All set!"
- [x] `poetry lock` regenerated cleanly
- [ ] CI: lint, tests, docs build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to align with current packaging standards. No changes to functionality or user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/mkdocs-terok/pull/72)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->