### PR TITLE
chore(pyproject): pin static version below packages so dynver build is a no-op

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ Security = "https://github.com/terok-ai/mkdocs-terok/security/policy"
 terok = "mkdocs_terok.plugin:TerokPlugin"
 
 [tool.poetry]
-version = "0.6.1a2"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
@@ -54,6 +53,7 @@ include = [
   { path = "src/mkdocs_terok/_assets/*.css" },
   { path = "src/mkdocs_terok/_assets/*.js" },
 ]
+version = "0.6.1a2"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.8"


### PR DESCRIPTION
## Summary

`poetry-dynamic-versioning` rewrites `pyproject.toml` at every build and restores the `version` key at the bottom of `[tool.poetry]`, not where it originally sat. Running `pipx install .` (or any `poetry build`) from a clean clone therefore left a dirty worktree:

```diff
 [tool.poetry]
-version = "X.Y.Z"
 classifiers = [ ... ]
 packages = [ ... ]
+version = "X.Y.Z"
```

Pre-positioning `version` where dynver restores it makes the build idempotent against the file. Verified locally: `cp pyproject.toml /tmp/before && poetry build && diff /tmp/before pyproject.toml` is empty.

## Release-script impact

terok-warden/terok-toolbox bumps this key on tag day. The new location is still inside `[tool.poetry]`, so a regex like `^version = "..."` keeps matching. If the script looks at line number rather than section context, it will need a one-line update.

## Test plan

- [x] `poetry build` leaves `pyproject.toml` unchanged.
- [ ] Same on consumer side via `pipx install .` from clean clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)