### PR TITLE
chore: drop unused _is_section_field

### DIFF
--- a/src/mkdocs_terok/config_reference.py
+++ b/src/mkdocs_terok/config_reference.py
@@ -338,11 +338,6 @@ def _unwrap_section_model(field_info: FieldInfo) -> type[BaseModel] | None:
     return None
 
 
-def _is_section_field(field_info: FieldInfo) -> bool:
-    """Check if a field is a nested Pydantic section model."""
-    return _unwrap_section_model(field_info) is not None
-
-
 def _md_escape(text: str) -> str:
     """Escape characters that would break a Markdown table cell."""
     return text.replace("|", r"\|").replace("\n", " ")


### PR DESCRIPTION
## Summary

- Drops the two-line `_is_section_field` wrapper at `src/mkdocs_terok/config_reference.py:341-343` — a thin call into `_unwrap_section_model` with zero callers anywhere in the six terok repos.

## Test plan

- [x] `make check` — lint, tests, docstring coverage 100%, deadcode, REUSE all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements for better maintainability. No user-facing changes or new features in this update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/mkdocs-terok/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->