### PR TITLE
chore: release 0.7.0 The Emissary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,10 @@
 # Changelog
+## v0.7.0 — The Emissary
+
+## What's Changed
+
+* lint that README install snippet stays in sync with pyproject version in https://github.com/terok-ai/mkdocs-terok/pull/70
+* migrate pyproject.toml to PEP 621 [project] table in https://github.com/terok-ai/mkdocs-terok/pull/72
+
+**Full Changelog**: https://github.com/terok-ai/mkdocs-terok/compare/v0.6.0...v0.7.0
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ include = [
   { path = "src/mkdocs_terok/_assets/*.css" },
   { path = "src/mkdocs_terok/_assets/*.js" },
 ]
-version = "0.6.1a2"
+version = "0.7.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.8"


### PR DESCRIPTION
Automated release bump to v0.7.0.