### PR TITLE
fix: handle complexipy v5.x cache format

### DIFF
--- a/src/mkdocs_terok/code_metrics.py
+++ b/src/mkdocs_terok/code_metrics.py
@@ -628,7 +628,9 @@ def _section_complexity(cfg: CodeMetricsConfig) -> str:
                 if isinstance(entry, dict):
                     functions.extend(entry.get("functions", []))
         except (json.JSONDecodeError, OSError):
-            return "!!! warning\n    complexipy cache is invalid JSON — skipping complexity report.\n"
+            return (
+                "!!! warning\n    complexipy cache is invalid JSON — skipping complexity report.\n"
+            )
     else:
         # Fall back to old cache format: .complexipy_cache/*.json
         cache_files = sorted(cache_dir.glob("*.json")) if cache_dir.is_dir() else []
@@ -639,7 +641,9 @@ def _section_complexity(cfg: CodeMetricsConfig) -> str:
         try:
             data = json.loads(latest_cache.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
-            return "!!! warning\n    complexipy cache is invalid JSON — skipping complexity report.\n"
+            return (
+                "!!! warning\n    complexipy cache is invalid JSON — skipping complexity report.\n"
+            )
 
         # Old format: {"functions": [...]}
         functions = [

--- a/src/mkdocs_terok/code_metrics.py
+++ b/src/mkdocs_terok/code_metrics.py
@@ -616,7 +616,7 @@ def _section_complexity(cfg: CodeMetricsConfig) -> str:
         return f"!!! warning\n    complexipy failed; skipping complexity report.\n\n```\n{output}\n```\n"
 
     cache_dir = cfg.root / ".complexipy_cache"
-    
+
     # Try new cache format first (complexipy >= 5.x): .complexipy_cache/v/cache/functions
     new_cache_file = cache_dir / "v" / "cache" / "functions"
     if new_cache_file.is_file():

--- a/src/mkdocs_terok/code_metrics.py
+++ b/src/mkdocs_terok/code_metrics.py
@@ -616,21 +616,37 @@ def _section_complexity(cfg: CodeMetricsConfig) -> str:
         return f"!!! warning\n    complexipy failed; skipping complexity report.\n\n```\n{output}\n```\n"
 
     cache_dir = cfg.root / ".complexipy_cache"
-    cache_files = sorted(cache_dir.glob("*.json")) if cache_dir.is_dir() else []
-    if not cache_files:
-        return "!!! warning\n    complexipy cache not found — skipping complexity report.\n"
+    
+    # Try new cache format first (complexipy >= 5.x): .complexipy_cache/v/cache/functions
+    new_cache_file = cache_dir / "v" / "cache" / "functions"
+    if new_cache_file.is_file():
+        try:
+            data = json.loads(new_cache_file.read_text(encoding="utf-8"))
+            # New format: {"entries": {"hash": {"functions": [...]}}}
+            functions: list[dict] = []
+            for entry in data.get("entries", {}).values():
+                if isinstance(entry, dict):
+                    functions.extend(entry.get("functions", []))
+        except (json.JSONDecodeError, OSError):
+            return "!!! warning\n    complexipy cache is invalid JSON — skipping complexity report.\n"
+    else:
+        # Fall back to old cache format: .complexipy_cache/*.json
+        cache_files = sorted(cache_dir.glob("*.json")) if cache_dir.is_dir() else []
+        if not cache_files:
+            return "!!! warning\n    complexipy cache not found — skipping complexity report.\n"
 
-    latest_cache = max(cache_files, key=lambda p: p.stat().st_mtime)
-    try:
-        data = json.loads(latest_cache.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return "!!! warning\n    complexipy cache is invalid JSON — skipping complexity report.\n"
+        latest_cache = max(cache_files, key=lambda p: p.stat().st_mtime)
+        try:
+            data = json.loads(latest_cache.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return "!!! warning\n    complexipy cache is invalid JSON — skipping complexity report.\n"
 
-    functions = [
-        f
-        for f in data.get("functions", [])
-        if isinstance(f, dict) and isinstance(f.get("complexity"), (int, float))
-    ]
+        # Old format: {"functions": [...]}
+        functions = [
+            f
+            for f in data.get("functions", [])
+            if isinstance(f, dict) and isinstance(f.get("complexity"), (int, float))
+        ]
     if not functions:
         return "No functions found.\n"
 

--- a/tests/test_code_metrics.py
+++ b/tests/test_code_metrics.py
@@ -299,6 +299,53 @@ def test_complexity_renders_histogram_with_v5_cache_format(tmp_path: Path) -> No
     assert "3" in result
 
 
+def test_complexity_v5_cache_invalid_json(tmp_path: Path) -> None:
+    """New v5 cache with invalid JSON should emit warning."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    cache_dir = tmp_path / ".complexipy_cache" / "v" / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "functions").write_text("{not valid json")
+
+    cfg = CodeMetricsConfig(root=tmp_path, src_dir=tmp_path / "src", tests_dir=tmp_path / "tests")
+    with patch("mkdocs_terok.code_metrics._run", return_value=_ok()):
+        result = _section_complexity(cfg)
+
+    assert "!!! warning" in result
+    assert "invalid JSON" in result
+
+
+def test_complexity_legacy_cache_invalid_json(tmp_path: Path) -> None:
+    """Legacy cache with invalid JSON should emit warning."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    cache_dir = tmp_path / ".complexipy_cache"
+    cache_dir.mkdir()
+    (cache_dir / "result.json").write_text("{not valid json")
+
+    cfg = CodeMetricsConfig(root=tmp_path, src_dir=tmp_path / "src", tests_dir=tmp_path / "tests")
+    with patch("mkdocs_terok.code_metrics._run", return_value=_ok()):
+        result = _section_complexity(cfg)
+
+    assert "!!! warning" in result
+    assert "invalid JSON" in result
+
+
+def test_complexity_no_functions_in_cache(tmp_path: Path) -> None:
+    """Cache with empty functions list should report no functions found."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    cache_dir = tmp_path / ".complexipy_cache" / "v" / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "functions").write_text(json.dumps({"entries": {}}))
+
+    cfg = CodeMetricsConfig(root=tmp_path, src_dir=tmp_path / "src", tests_dir=tmp_path / "tests")
+    with patch("mkdocs_terok.code_metrics._run", return_value=_ok()):
+        result = _section_complexity(cfg)
+
+    assert "No functions found" in result
+
+
 def test_dead_code_renders_table_when_vulture_finds_issues(tmp_path: Path) -> None:
     """Dead code section should render a table when vulture reports findings."""
     (tmp_path / "src").mkdir()

--- a/tests/test_code_metrics.py
+++ b/tests/test_code_metrics.py
@@ -230,6 +230,29 @@ _COMPLEXIPY_CACHE = json.dumps(
     }
 )
 
+# New complexipy v5.x cache format (stored at .complexipy_cache/v/cache/functions)
+_COMPLEXIPY_CACHE_V5 = json.dumps(
+    {
+        "entries": {
+            "hash123": {
+                "functions": [
+                    {"function_name": "foo", "path": "pkg/mod.py", "complexity": 5},
+                    {"function_name": "bar", "path": "pkg/mod.py", "complexity": 20},
+                ],
+                "targets": ["pkg/mod.py"],
+                "updated_at": "2026-01-01T00:00:00Z",
+            },
+            "hash456": {
+                "functions": [
+                    {"function_name": "baz", "path": "pkg/other.py", "complexity": 3},
+                ],
+                "targets": ["pkg/other.py"],
+                "updated_at": "2026-01-01T00:00:00Z",
+            },
+        }
+    }
+)
+
 
 def test_complexity_renders_histogram_when_complexipy_succeeds(tmp_path: Path) -> None:
     """Complexity section should show histogram and top offenders."""
@@ -250,6 +273,30 @@ def test_complexity_renders_histogram_when_complexipy_succeeds(tmp_path: Path) -
     # bar with complexity 20 exceeds default threshold of 15
     assert "`bar`" in result
     assert "exceeding threshold" in result
+
+
+def test_complexity_renders_histogram_with_v5_cache_format(tmp_path: Path) -> None:
+    """Complexity section should work with complexipy v5.x cache format."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    cache_dir = tmp_path / ".complexipy_cache" / "v" / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "functions").write_text(_COMPLEXIPY_CACHE_V5)
+
+    cfg = CodeMetricsConfig(root=tmp_path, src_dir=tmp_path / "src", tests_dir=tmp_path / "tests")
+    with patch("mkdocs_terok.code_metrics._run", return_value=_ok()):
+        result = _section_complexity(cfg)
+
+    assert "!!! warning" not in result
+    assert "Functions analyzed" in result
+    assert "Median complexity" in result
+    assert "█" in result
+    # bar with complexity 20 exceeds default threshold of 15
+    assert "`bar`" in result
+    assert "exceeding threshold" in result
+    # Should aggregate functions from multiple entries (3 functions total)
+    assert "Functions analyzed" in result
+    assert "3" in result
 
 
 def test_dead_code_renders_table_when_vulture_finds_issues(tmp_path: Path) -> None:


### PR DESCRIPTION
complexipy 5.x introduced a new cache format stored at `.complexipy_cache/v/cache/functions` with a different JSON structure (`{"entries": {"hash": {"functions": [...]}}}`) instead of the legacy `.complexipy_cache/*.json` format (`{"functions": [...]}`).

This change adds support for both formats by checking for the new format first and falling back to the legacy format if not found.

Fixes the "complexipy cache not found — skipping complexity report" error in generated documentation.