### PR TITLE
docs: homepage URL to GitHub Pages + terok cross-link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # mkdocs-terok
 
-Shared [ProperDocs](https://properdocs.org/) documentation generators for terok projects.
+Shared [ProperDocs](https://properdocs.org/) documentation generators for [terok](https://terok-ai.github.io/terok/) projects.
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://terok.ai/"
+Homepage = "https://terok-ai.github.io/mkdocs-terok/"
 Repository = "https://github.com/terok-ai/mkdocs-terok"
 Documentation = "https://terok-ai.github.io/mkdocs-terok/"
 Issues = "https://github.com/terok-ai/mkdocs-terok/issues"


### PR DESCRIPTION
Aligns mkdocs-terok's docs metadata with the rest of the terok ecosystem (matching the sibling docs/metadata PRs):

- `[project.urls] Homepage`: `https://terok.ai/` → `https://terok-ai.github.io/mkdocs-terok/` (gives a verified link on PyPI; matches the existing `Documentation` URL).
- `docs/index.md`: cross-link "terok" to the main terok docs site.

mkdocs-terok already carries `mkdocs-material >=9.7.6` / `mkdocstrings >=0.26` (it's their source), so no dependency changes are needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)