### PR TITLE
feat(versions): versioned docs trees + reusable publish workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,10 +41,6 @@ jobs:
     permissions:
       contents: read
       actions: read
-    outputs:
-      version: ${{ steps.target.outputs.version }}
-      title: ${{ steps.target.outputs.title }}
-      aliases: ${{ steps.target.outputs.aliases }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -136,51 +132,56 @@ jobs:
       - name: Build documentation
         run: poetry run properdocs build --strict
 
-      # Master pushes refresh /dev/; a release call (release.yml, on the
-      # tag ref) lands in /<minor>/ titled with the full version and moves
-      # the `latest` alias.  Only final vX.Y.Z tags qualify: alphas never
-      # reach pypi-publish, so a non-final ref here is a mis-dispatch and
-      # fails loudly rather than minting a docs version.
-      - name: Compute versioned-docs target
-        id: target
-        env:
-          RELEASE: ${{ inputs.release || false }}
-        run: |
-          set -euo pipefail
-          if [[ "$RELEASE" == "true" ]]; then
-            if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "Release docs publish requires a final v*.*.* tag ref (got: $GITHUB_REF_NAME)" >&2
-              exit 1
-            fi
-            full="${GITHUB_REF_NAME#v}"
-            {
-              echo "version=${full%.*}"
-              echo "title=$full"
-              echo "aliases=latest"
-            } >> "$GITHUB_OUTPUT"
-          else
-            {
-              echo "version=dev"
-              echo "title="
-              echo "aliases="
-            } >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Upload site for versioned publish
         uses: actions/upload-artifact@v7
         with:
           name: docs-site
           path: site/
 
-  # Local reference: this repo ships the reusable workflow, so it consumes
-  # its own copy — consumers pin it by tag instead.
-  publish:
-    if: github.repository == 'terok-ai/mkdocs-terok' && (github.ref == 'refs/heads/master' || inputs.release)
+  # A release call ships the built site as an immutable snapshot asset on
+  # the tag's GitHub release; the assembler serves it as /<minor>/ from
+  # here on.  Final vX.Y.Z tags only: alphas never reach pypi-publish, so
+  # a non-final ref here is a mis-dispatch and fails loudly.
+  attach:
+    if: inputs.release
     needs: build
+    runs-on: ubuntu-latest
     permissions:
       contents: write
+    steps:
+      - name: Require a final release tag
+        run: |
+          set -euo pipefail
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release docs publish requires a final v*.*.* tag ref (got: $GITHUB_REF_NAME)" >&2
+            exit 1
+          fi
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: docs-site
+          path: site
+
+      - name: Upload snapshot to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tar -czf docs-site.tar.gz -C site .
+          gh release upload "$GITHUB_REF_NAME" docs-site.tar.gz --clobber --repo "$GITHUB_REPOSITORY"
+
+  # Local reference: this repo ships the reusable workflow, so it consumes
+  # its own copy — consumers pin it by tag instead.  Runs after attach on
+  # the release path so the fresh snapshot is in the release list; attach
+  # is skipped on master pushes.
+  publish:
+    if: >-
+      !cancelled() && needs.build.result == 'success' &&
+      (needs.attach.result == 'success' || needs.attach.result == 'skipped') &&
+      github.repository == 'terok-ai/mkdocs-terok' && (github.ref == 'refs/heads/master' || inputs.release)
+    needs: [build, attach]
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     uses: ./.github/workflows/publish-versioned-docs.yml
-    with:
-      version: ${{ needs.build.outputs.version }}
-      title: ${{ needs.build.outputs.title }}
-      aliases: ${{ needs.build.outputs.aliases }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -138,50 +138,15 @@ jobs:
           name: docs-site
           path: site/
 
-  # A release call ships the built site as an immutable snapshot asset on
-  # the tag's GitHub release; the assembler serves it as /<minor>/ from
-  # here on.  Final vX.Y.Z tags only: alphas never reach pypi-publish, so
-  # a non-final ref here is a mis-dispatch and fails loudly.
-  attach:
-    if: inputs.release
+  # Local reference: this repo ships the reusable workflow, so it consumes
+  # its own copy — consumers pin it by tag instead.
+  publish:
+    if: github.repository == 'terok-ai/mkdocs-terok' && (github.ref == 'refs/heads/master' || inputs.release)
     needs: build
-    runs-on: ubuntu-latest
     permissions:
       contents: write
-    steps:
-      - name: Require a final release tag
-        run: |
-          set -euo pipefail
-          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Release docs publish requires a final v*.*.* tag ref (got: $GITHUB_REF_NAME)" >&2
-            exit 1
-          fi
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: docs-site
-          path: site
-
-      - name: Upload snapshot to the release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          tar -czf docs-site.tar.gz -C site .
-          gh release upload "$GITHUB_REF_NAME" docs-site.tar.gz --clobber --repo "$GITHUB_REPOSITORY"
-
-  # Local reference: this repo ships the reusable workflow, so it consumes
-  # its own copy — consumers pin it by tag instead.  Runs after attach on
-  # the release path so the fresh snapshot is in the release list; attach
-  # is skipped on master pushes.
-  publish:
-    if: >-
-      !cancelled() && needs.build.result == 'success' &&
-      (needs.attach.result == 'success' || needs.attach.result == 'skipped') &&
-      github.repository == 'terok-ai/mkdocs-terok' && (github.ref == 'refs/heads/master' || inputs.release)
-    needs: [build, attach]
-    permissions:
-      contents: read
       pages: write
       id-token: write
     uses: ./.github/workflows/publish-versioned-docs.yml
+    with:
+      release: ${{ inputs.release == true }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,15 @@ on:
   push:
     branches: [master]
   workflow_dispatch:
+  # release.yml calls this after a successful PyPI publish: the same build
+  # runs on the tag ref and lands in the versioned tree as /<minor>/ with
+  # the `latest` alias, instead of /dev/.
+  workflow_call:
+    inputs:
+      release:
+        description: "Publish as the release version derived from the tag ref (instead of dev)"
+        type: boolean
+        default: false
 
 permissions: {}
 
@@ -27,11 +36,15 @@ concurrency:
 
 jobs:
   build:
-    if: github.repository == 'terok-ai/mkdocs-terok' && github.ref == 'refs/heads/master'
+    if: github.repository == 'terok-ai/mkdocs-terok' && (github.ref == 'refs/heads/master' || inputs.release)
     runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: read
+    outputs:
+      version: ${{ steps.target.outputs.version }}
+      title: ${{ steps.target.outputs.title }}
+      aliases: ${{ steps.target.outputs.aliases }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -123,22 +136,51 @@ jobs:
       - name: Build documentation
         run: poetry run properdocs build --strict
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+      # Master pushes refresh /dev/; a release call (release.yml, on the
+      # tag ref) lands in /<minor>/ titled with the full version and moves
+      # the `latest` alias.  Only final vX.Y.Z tags qualify: alphas never
+      # reach pypi-publish, so a non-final ref here is a mis-dispatch and
+      # fails loudly rather than minting a docs version.
+      - name: Compute versioned-docs target
+        id: target
+        env:
+          RELEASE: ${{ inputs.release || false }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE" == "true" ]]; then
+            if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Release docs publish requires a final v*.*.* tag ref (got: $GITHUB_REF_NAME)" >&2
+              exit 1
+            fi
+            full="${GITHUB_REF_NAME#v}"
+            {
+              echo "version=${full%.*}"
+              echo "title=$full"
+              echo "aliases=latest"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "version=dev"
+              echo "title="
+              echo "aliases="
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload site for versioned publish
+        uses: actions/upload-artifact@v7
         with:
+          name: docs-site
           path: site/
 
-  deploy:
-    if: github.repository == 'terok-ai/mkdocs-terok' && github.ref == 'refs/heads/master'
+  # Local reference: this repo ships the reusable workflow, so it consumes
+  # its own copy — consumers pin it by tag instead.
+  publish:
+    if: github.repository == 'terok-ai/mkdocs-terok' && (github.ref == 'refs/heads/master' || inputs.release)
     needs: build
-    runs-on: ubuntu-latest
     permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      contents: write
+    uses: ./.github/workflows/publish-versioned-docs.yml
+    with:
+      version: ${{ needs.build.outputs.version }}
+      title: ${{ needs.build.outputs.title }}
+      aliases: ${{ needs.build.outputs.aliases }}

--- a/.github/workflows/publish-versioned-docs.yml
+++ b/.github/workflows/publish-versioned-docs.yml
@@ -52,17 +52,17 @@ on:
 
 permissions: {}
 
-# One tree mutation at a time per repo: a master `dev` deploy racing a
-# release deploy would clobber the other's gh-pages push.
-concurrency:
-  group: versioned-docs-${{ github.repository }}
-  cancel-in-progress: false
-
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # One tree mutation at a time per repo: a master `dev` deploy racing
+    # a release deploy would clobber the other's gh-pages push.  Job-level
+    # because workflow-level concurrency is ignored under workflow_call.
+    concurrency:
+      group: versioned-docs-${{ github.repository }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/publish-versioned-docs.yml
+++ b/.github/workflows/publish-versioned-docs.yml
@@ -1,22 +1,25 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: 0BSD
 
-# Reusable workflow: assemble and deploy the calling repo's versioned
-# docs site.  Stateless model — every deploy rebuilds the whole served
-# tree from immutable per-release snapshot assets (docs-site.tar.gz,
-# uploaded by the caller's release flow) plus the fresh /dev/ build the
-# caller hands over as an artifact; versions.json (Material's chooser
-# contract) is derived from the release list.  Nothing persists between
-# deploys: no gh-pages branch, no history, and retention is just the
-# `keep` parameter.
+# Reusable workflow: publish the calling repo's versioned docs site.
+# Stateless model — every deploy rebuilds the whole served tree from
+# immutable per-release snapshot assets (docs-site.tar.gz) plus the
+# fresh /dev/ build the caller hands over as the `docs-site` artifact;
+# versions.json (Material's chooser contract) is derived from the
+# release list.  Nothing persists between deploys: no gh-pages branch,
+# no history, and retention is just the `keep` parameter.
+#
+# On a release call (`release: true`, running on the tag ref) the same
+# job first ships the built site as the tag's snapshot asset, so the
+# subsequent plan step already sees the new release.
 #
 # Like publish-inventory.yml, the selection/layout logic runs from the
 # calling repo's locked docs environment (mkdocs_terok.versions), so the
 # caller's mkdocs-terok pin decides which version of it applies.
 #
-# The calling job must grant `pages: write`, `id-token: write` and
-# `contents: read`; the repo's github-pages environment must allow
-# deployments from v* tags (release deploys run on the tag ref).
+# The calling job must grant `contents: write` (release-asset upload),
+# `pages: write` and `id-token: write`; the repo's github-pages
+# environment must allow deployments from v* tags.
 #
 # Pin third-party actions to full commit SHAs.  GitHub-owned actions
 # (actions/*) may use version tags.
@@ -26,10 +29,10 @@ name: Publish versioned docs (reusable)
 on:
   workflow_call:
     inputs:
-      site-artifact:
-        description: "Name of the uploaded artifact holding the built dev/release site"
-        type: string
-        default: "docs-site"
+      release:
+        description: "Ship the built site as the tag's snapshot asset before deploying (run on a final v*.*.* tag ref)"
+        type: boolean
+        default: false
       keep:
         description: "How many newest minors to serve; older releases stay downloadable as assets"
         type: number
@@ -49,7 +52,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pages: write
       id-token: write
     environment:
@@ -89,12 +92,32 @@ jobs:
           INSTALL_ARGS: ${{ inputs.poetry-install-args }}
         run: poetry install $INSTALL_ARGS
 
-      - name: Download built dev site
+      - name: Download built site
         uses: actions/download-artifact@v8
         with:
-          name: ${{ inputs.site-artifact }}
+          name: docs-site
           path: ${{ runner.temp }}/dev-site
 
+      # Final vX.Y.Z tags only: alphas never reach pypi-publish, so a
+      # non-final ref here is a mis-dispatch and fails loudly rather
+      # than minting a docs version.  Snapshot tarballs hold the site
+      # contents at the archive root.
+      - name: Ship the release snapshot asset
+        if: inputs.release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release docs publish requires a final v*.*.* tag ref (got: $GITHUB_REF_NAME)" >&2
+            exit 1
+          fi
+          tar -czf docs-site.tar.gz -C "$RUNNER_TEMP/dev-site" .
+          gh release upload "$GITHUB_REF_NAME" docs-site.tar.gz --clobber --repo "$GITHUB_REPOSITORY"
+          rm docs-site.tar.gz
+
+      # plan.json lives in the workspace so hashFiles() can key the
+      # snapshot cache on it.
       - name: Plan served snapshots from the release list
         env:
           GH_TOKEN: ${{ github.token }}
@@ -105,30 +128,42 @@ jobs:
             > "$RUNNER_TEMP/releases.json"
           poetry run python -m mkdocs_terok.versions plan \
             --releases "$RUNNER_TEMP/releases.json" --keep "$KEEP" \
-            | tee "$RUNNER_TEMP/plan.json"
+            | tee plan.json
 
-      # Snapshot tarballs hold the site contents at the archive root
-      # (created with ``tar -czf docs-site.tar.gz -C site .``).
+      # Snapshot tarballs are immutable per tag, so the download is
+      # skipped entirely until the served set changes.
+      - name: Restore cached snapshot tarballs
+        id: snapshot-cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/tarballs
+          key: versioned-docs-snapshots-${{ hashFiles('plan.json') }}
+
       - name: Download served snapshots
+        if: steps.snapshot-cache.outputs.cache-hit != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/snapshots"
-          jq -r '.[] | "\(.minor) \(.tag)"' "$RUNNER_TEMP/plan.json" \
+          mkdir -p "$RUNNER_TEMP/tarballs"
+          jq -r '.[] | "\(.minor) \(.tag)"' plan.json \
           | while read -r minor tag; do
-              mkdir "$RUNNER_TEMP/snapshots/$minor"
-              gh release download "$tag" --pattern docs-site.tar.gz --output - \
-                | tar -xz -C "$RUNNER_TEMP/snapshots/$minor"
+              gh release download "$tag" --pattern docs-site.tar.gz \
+                --output "$RUNNER_TEMP/tarballs/$minor.tar.gz"
             done
 
       - name: Assemble the site tree
         run: |
           set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/snapshots"
+          jq -r '.[].minor' plan.json | while read -r minor; do
+            mkdir "$RUNNER_TEMP/snapshots/$minor"
+            tar -xzf "$RUNNER_TEMP/tarballs/$minor.tar.gz" -C "$RUNNER_TEMP/snapshots/$minor"
+          done
           poetry run python -m mkdocs_terok.versions assemble \
             --dev "$RUNNER_TEMP/dev-site" \
             --snapshots "$RUNNER_TEMP/snapshots" \
-            --plan "$RUNNER_TEMP/plan.json" \
+            --plan plan.json \
             --out "$RUNNER_TEMP/tree"
 
       - name: Setup Pages

--- a/.github/workflows/publish-versioned-docs.yml
+++ b/.github/workflows/publish-versioned-docs.yml
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: 0BSD
+
+# Reusable workflow: install a built docs site into the calling repo's
+# versioned gh-pages tree and push it.  The tree follows the mike layout
+# (one directory per version, `versions.json` at the root driving
+# Material's version chooser, alias directories like `latest/`, and a
+# root redirect) — maintained by `mkdocs_terok.versions` because mike
+# itself cannot drive ProperDocs builds.
+#
+# The caller builds its site exactly as before (ProperDocs, coverage
+# treemap and all) and uploads it as a regular artifact; only the tree
+# shuffle is shared here.  Like publish-inventory.yml, the python module
+# runs from the calling repo's locked docs environment, so the caller's
+# mkdocs-terok pin decides which version of the tree logic applies.
+#
+# The calling job must grant `contents: write` (gh-pages push) and the
+# repo's Pages source must be "deploy from branch: gh-pages".
+#
+# Pin third-party actions to full commit SHAs.  GitHub-owned actions
+# (actions/*) may use version tags.
+
+name: Publish versioned docs (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version directory and chooser id (e.g. `0.8` or `dev`)"
+        type: string
+        required: true
+      title:
+        description: "Chooser label (e.g. `0.8.2`); defaults to the version"
+        type: string
+        default: ""
+      aliases:
+        description: "Space-separated alias directories re-pointed at this version (e.g. `latest`)"
+        type: string
+        default: ""
+      site-artifact:
+        description: "Name of the uploaded artifact holding the built site"
+        type: string
+        default: "docs-site"
+      python-version:
+        description: "Python version used to run the tree maintainer"
+        type: string
+        default: "3.12"
+      poetry-install-args:
+        description: "Args passed to ``poetry install``.  Default uses ``--only`` to skip dev/test groups, which often pull system-dep'd build-from-source packages that aren't needed to run `mkdocs_terok.versions`."
+        type: string
+        default: "--only main,docs --no-interaction"
+
+permissions: {}
+
+# One tree mutation at a time per repo: a master `dev` deploy racing a
+# release deploy would clobber the other's gh-pages push.
+concurrency:
+  group: versioned-docs-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install dynamic versioning plugin
+        run: poetry self add "poetry-dynamic-versioning[plugin]>=1.0.0,<2.0.0"
+
+      - name: Load cached venv
+        uses: actions/cache@v6
+        with:
+          path: .venv
+          key: venv-versioned-docs-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
+
+      - name: Install dependencies
+        env:
+          INSTALL_ARGS: ${{ inputs.poetry-install-args }}
+        run: poetry install $INSTALL_ARGS
+
+      - name: Download built site
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.site-artifact }}
+          path: ${{ runner.temp }}/site
+
+      # The tree accumulates on gh-pages; a worktree keeps it apart from
+      # the default-branch checkout that carries the poetry environment.
+      - name: Check out the docs tree (gh-pages)
+        run: |
+          set -euo pipefail
+          if git fetch origin +gh-pages:refs/remotes/origin/gh-pages; then
+            git worktree add -B gh-pages tree origin/gh-pages
+          else
+            git worktree add --orphan -b gh-pages tree
+          fi
+
+      - name: Install site into the tree
+        env:
+          VERSION: ${{ inputs.version }}
+          TITLE: ${{ inputs.title }}
+          ALIASES: ${{ inputs.aliases }}
+        run: |
+          set -euo pipefail
+          args=(--site "$RUNNER_TEMP/site" --tree tree --version "$VERSION")
+          if [[ -n "$TITLE" ]]; then
+            args+=(--title "$TITLE")
+          fi
+          for alias in $ALIASES; do
+            args+=(--alias "$alias")
+          done
+          poetry run python -m mkdocs_terok.versions "${args[@]}"
+
+      - name: Push the docs tree
+        env:
+          VERSION: ${{ inputs.version }}
+          TITLE: ${{ inputs.title }}
+        run: |
+          set -euo pipefail
+          cd tree
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Tree unchanged — nothing to publish."
+            exit 0
+          fi
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -m "docs: publish ${VERSION}${TITLE:+ (${TITLE})}"
+          git push origin gh-pages

--- a/.github/workflows/publish-versioned-docs.yml
+++ b/.github/workflows/publish-versioned-docs.yml
@@ -64,7 +64,12 @@ jobs:
       group: versioned-docs-${{ github.repository }}
       cancel-in-progress: false
     steps:
+      # Read-only checkout: later steps run third-party code (poetry
+      # install) and all gh/git access goes through the GH_TOKEN env,
+      # so the token must not linger in git config.
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         id: setup-python

--- a/.github/workflows/publish-versioned-docs.yml
+++ b/.github/workflows/publish-versioned-docs.yml
@@ -1,21 +1,22 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: 0BSD
 
-# Reusable workflow: install a built docs site into the calling repo's
-# versioned gh-pages tree and push it.  The tree follows the mike layout
-# (one directory per version, `versions.json` at the root driving
-# Material's version chooser, alias directories like `latest/`, and a
-# root redirect) — maintained by `mkdocs_terok.versions` because mike
-# itself cannot drive ProperDocs builds.
+# Reusable workflow: assemble and deploy the calling repo's versioned
+# docs site.  Stateless model — every deploy rebuilds the whole served
+# tree from immutable per-release snapshot assets (docs-site.tar.gz,
+# uploaded by the caller's release flow) plus the fresh /dev/ build the
+# caller hands over as an artifact; versions.json (Material's chooser
+# contract) is derived from the release list.  Nothing persists between
+# deploys: no gh-pages branch, no history, and retention is just the
+# `keep` parameter.
 #
-# The caller builds its site exactly as before (ProperDocs, coverage
-# treemap and all) and uploads it as a regular artifact; only the tree
-# shuffle is shared here.  Like publish-inventory.yml, the python module
-# runs from the calling repo's locked docs environment, so the caller's
-# mkdocs-terok pin decides which version of the tree logic applies.
+# Like publish-inventory.yml, the selection/layout logic runs from the
+# calling repo's locked docs environment (mkdocs_terok.versions), so the
+# caller's mkdocs-terok pin decides which version of it applies.
 #
-# The calling job must grant `contents: write` (gh-pages push) and the
-# repo's Pages source must be "deploy from branch: gh-pages".
+# The calling job must grant `pages: write`, `id-token: write` and
+# `contents: read`; the repo's github-pages environment must allow
+# deployments from v* tags (release deploys run on the tag ref).
 #
 # Pin third-party actions to full commit SHAs.  GitHub-owned actions
 # (actions/*) may use version tags.
@@ -25,24 +26,16 @@ name: Publish versioned docs (reusable)
 on:
   workflow_call:
     inputs:
-      version:
-        description: "Version directory and chooser id (e.g. `0.8` or `dev`)"
-        type: string
-        required: true
-      title:
-        description: "Chooser label (e.g. `0.8.2`); defaults to the version"
-        type: string
-        default: ""
-      aliases:
-        description: "Space-separated alias directories re-pointed at this version (e.g. `latest`)"
-        type: string
-        default: ""
       site-artifact:
-        description: "Name of the uploaded artifact holding the built site"
+        description: "Name of the uploaded artifact holding the built dev/release site"
         type: string
         default: "docs-site"
+      keep:
+        description: "How many newest minors to serve; older releases stay downloadable as assets"
+        type: number
+        default: 6
       python-version:
-        description: "Python version used to run the tree maintainer"
+        description: "Python version used to run the assembler"
         type: string
         default: "3.12"
       poetry-install-args:
@@ -56,10 +49,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-    # One tree mutation at a time per repo: a master `dev` deploy racing
-    # a release deploy would clobber the other's gh-pages push.  Job-level
-    # because workflow-level concurrency is ignored under workflow_call.
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    # One deploy at a time per repo; a superseded assembly would only
+    # redo identical work, so don't cancel mid-flight.
     concurrency:
       group: versioned-docs-${{ github.repository }}
       cancel-in-progress: false
@@ -92,54 +89,56 @@ jobs:
           INSTALL_ARGS: ${{ inputs.poetry-install-args }}
         run: poetry install $INSTALL_ARGS
 
-      - name: Download built site
+      - name: Download built dev site
         uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.site-artifact }}
-          path: ${{ runner.temp }}/site
+          path: ${{ runner.temp }}/dev-site
 
-      # The tree accumulates on gh-pages; a worktree keeps it apart from
-      # the default-branch checkout that carries the poetry environment.
-      # Depth 1: only the tip tree matters (deploys append full-state
-      # commits), so the fetch stays O(site) instead of O(history).
-      - name: Check out the docs tree (gh-pages)
-        run: |
-          set -euo pipefail
-          if git fetch --depth 1 origin +gh-pages:refs/remotes/origin/gh-pages; then
-            git worktree add -B gh-pages tree origin/gh-pages
-          else
-            git worktree add --orphan -b gh-pages tree
-          fi
-
-      - name: Install site into the tree
+      - name: Plan served snapshots from the release list
         env:
-          VERSION: ${{ inputs.version }}
-          TITLE: ${{ inputs.title }}
-          ALIASES: ${{ inputs.aliases }}
+          GH_TOKEN: ${{ github.token }}
+          KEEP: ${{ inputs.keep }}
         run: |
           set -euo pipefail
-          args=(--site "$RUNNER_TEMP/site" --tree tree --version "$VERSION")
-          if [[ -n "$TITLE" ]]; then
-            args+=(--title "$TITLE")
-          fi
-          for alias in $ALIASES; do
-            args+=(--alias "$alias")
-          done
-          poetry run python -m mkdocs_terok.versions "${args[@]}"
+          gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --paginate \
+            > "$RUNNER_TEMP/releases.json"
+          poetry run python -m mkdocs_terok.versions plan \
+            --releases "$RUNNER_TEMP/releases.json" --keep "$KEEP" \
+            | tee "$RUNNER_TEMP/plan.json"
 
-      - name: Push the docs tree
+      # Snapshot tarballs hold the site contents at the archive root
+      # (created with ``tar -czf docs-site.tar.gz -C site .``).
+      - name: Download served snapshots
         env:
-          VERSION: ${{ inputs.version }}
-          TITLE: ${{ inputs.title }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          cd tree
-          git add -A
-          if git diff --cached --quiet; then
-            echo "Tree unchanged — nothing to publish."
-            exit 0
-          fi
-          git -c user.name="github-actions[bot]" \
-              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
-              commit -m "docs: publish ${VERSION}${TITLE:+ (${TITLE})}"
-          git push origin gh-pages
+          mkdir -p "$RUNNER_TEMP/snapshots"
+          jq -r '.[] | "\(.minor) \(.tag)"' "$RUNNER_TEMP/plan.json" \
+          | while read -r minor tag; do
+              mkdir "$RUNNER_TEMP/snapshots/$minor"
+              gh release download "$tag" --pattern docs-site.tar.gz --output - \
+                | tar -xz -C "$RUNNER_TEMP/snapshots/$minor"
+            done
+
+      - name: Assemble the site tree
+        run: |
+          set -euo pipefail
+          poetry run python -m mkdocs_terok.versions assemble \
+            --dev "$RUNNER_TEMP/dev-site" \
+            --snapshots "$RUNNER_TEMP/snapshots" \
+            --plan "$RUNNER_TEMP/plan.json" \
+            --out "$RUNNER_TEMP/tree"
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: ${{ runner.temp }}/tree
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-versioned-docs.yml
+++ b/.github/workflows/publish-versioned-docs.yml
@@ -100,10 +100,12 @@ jobs:
 
       # The tree accumulates on gh-pages; a worktree keeps it apart from
       # the default-branch checkout that carries the poetry environment.
+      # Depth 1: only the tip tree matters (deploys append full-state
+      # commits), so the fetch stays O(site) instead of O(history).
       - name: Check out the docs tree (gh-pages)
         run: |
           set -euo pipefail
-          if git fetch origin +gh-pages:refs/remotes/origin/gh-pages; then
+          if git fetch --depth 1 origin +gh-pages:refs/remotes/origin/gh-pages; then
             git worktree add -B gh-pages tree origin/gh-pages
           else
             git worktree add --orphan -b gh-pages tree

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,8 @@ jobs:
     permissions:
       contents: write
       actions: read
+      pages: write
+      id-token: write
     uses: ./.github/workflows/docs.yml
     with:
       release: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,18 @@ jobs:
         with:
           attestations: true
 
+  # Versioned docs exist only for what users can `pip install`: publish
+  # the /<minor>/ snapshot (and move `latest`) strictly after the PyPI
+  # upload succeeded.  gh-only and testpypi targets deliberately skip this.
+  docs-version:
+    needs: pypi-publish
+    permissions:
+      contents: write
+      actions: read
+    uses: ./.github/workflows/docs.yml
+    with:
+      release: true
+
   testpypi-publish:
     needs: build
     if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -17,8 +17,8 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
 
-# "mike" names the versions.json contract, not the tool: the versioned
-# tree on gh-pages is maintained by mkdocs_terok.versions via the
+# "mike" names the versions.json contract, not the tool: the deployed
+# versioned tree is assembled by mkdocs_terok.versions via the
 # publish-versioned-docs.yml reusable workflow.
 extra:
   version:

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -17,6 +17,13 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
 
+# "mike" names the versions.json contract, not the tool: the versioned
+# tree on gh-pages is maintained by mkdocs_terok.versions via the
+# publish-versioned-docs.yml reusable workflow.
+extra:
+  version:
+    provider: mike
+
 plugins:
   - search
   - terok:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ include = [
   { path = "src/mkdocs_terok/_assets/*.css" },
   { path = "src/mkdocs_terok/_assets/*.js" },
 ]
-version = "0.7.1"
+version = "0.7.2a1"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.8"

--- a/src/mkdocs_terok/inventory.py
+++ b/src/mkdocs_terok/inventory.py
@@ -47,11 +47,20 @@ _SIBLING_INVENTORY_URL = re.compile(
     r")"
 )
 
-#: Matches a YAML list item whose value is a sibling inventory URL,
-#: e.g. ``    - https://terok-ai.github.io/terok-sandbox/objects.inv``.
-#: Anchored on ``- `` so plain dependency-list URLs elsewhere in the
-#: file (which never start with ``- ``) are left untouched.
-_INVENTORY_LINE = re.compile(rf"^\s*-\s+{_SIBLING_INVENTORY_URL.pattern}\S*\s*$")
+#: Matches a YAML list item whose value is a sibling inventory URL — the
+#: bare form (``- https://terok-ai.github.io/terok-sandbox/objects.inv``)
+#: or the single-line flow-mapping form consumers use to carry an explicit
+#: link base (``- { url: https://raw.githubusercontent.com/..., base_url:
+#: https://terok-ai.github.io/terok-sandbox/ }``).  Anchored on ``- `` so
+#: plain dependency-list URLs elsewhere in the file (which never start
+#: with ``- ``) are left untouched.
+_INVENTORY_LINE = re.compile(
+    rf"^\s*-\s+(?:"
+    rf"{_SIBLING_INVENTORY_URL.pattern}\S*"
+    rf"|"
+    rf"\{{.*{_SIBLING_INVENTORY_URL.pattern}.*\}}"
+    rf")\s*$"
+)
 
 
 def build_inventory(*, config: Path, output: Path) -> None:

--- a/src/mkdocs_terok/versions.py
+++ b/src/mkdocs_terok/versions.py
@@ -24,11 +24,17 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import shutil
 from collections.abc import Sequence
 from pathlib import Path
 
 _VERSIONS_FILE = "versions.json"
+
+#: Version and alias names become directory names inside the tree, so they
+#: must be single path components — no separators, no leading dot (which
+#: also rules out ``..``).
+_SAFE_COMPONENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 
 _ROOT_REDIRECT = """\
 <!DOCTYPE html>
@@ -65,7 +71,15 @@ def deploy(
             (``0.8.2``).  Defaults to *version*.
         aliases: Alias directories re-pointed at this version
             (typically ``latest``).
+
+    Raises:
+        ValueError: *version* or an alias is not a plain directory name
+            (path separators, a leading dot, or empty), which would let a
+            crafted CLI argument write outside the tree.
     """
+    for name in (version, *aliases):
+        if not _SAFE_COMPONENT.fullmatch(name):
+            raise ValueError(f"unsafe tree directory name: {name!r}")
     entries = _upsert(
         _load_entries(tree), version=version, title=title or version, aliases=list(aliases)
     )

--- a/src/mkdocs_terok/versions.py
+++ b/src/mkdocs_terok/versions.py
@@ -37,6 +37,10 @@ DOCS_ASSET = "docs-site.tar.gz"
 #: Final releases only — alphas never reach PyPI and mint no docs.
 _FINAL_TAG = re.compile(r"v(\d+)\.(\d+)\.(\d+)")
 
+#: Minors become directory names inside the tree; anything else in a
+#: ``--plan`` file (path separators, ``..``) must not reach a path join.
+_MINOR = re.compile(r"\d+\.\d+")
+
 _ROOT_REDIRECT = """\
 <!DOCTYPE html>
 <html>
@@ -92,14 +96,18 @@ def assemble(*, dev_site: Path, snapshots: Path, entries: list[dict], out: Path)
         dev_site: Freshly built ProperDocs output for master.
         snapshots: Directory holding one unpacked snapshot per served
             minor (``snapshots/<minor>/``), as planned by
-            [`mkdocs_terok.versions.plan`][].
+            [`plan`][mkdocs_terok.versions.plan].
         entries: The plan — newest minor first.
         out: Tree to create; replaced wholesale if it exists.
 
     Raises:
-        ValueError: *out* points at an existing non-empty directory that
-            is not a previously assembled tree (mispointed ``--out``).
+        ValueError: an entry's ``minor`` is not a plain ``X.Y`` name, or
+            *out* points at an existing non-empty directory that is not
+            a previously assembled tree (mispointed ``--out``).
     """
+    for entry in entries:
+        if not _MINOR.fullmatch(entry["minor"]):
+            raise ValueError(f"unsafe minor in plan: {entry['minor']!r}")
     _ensure_replaceable(out)
     if out.exists():
         shutil.rmtree(out)

--- a/src/mkdocs_terok/versions.py
+++ b/src/mkdocs_terok/versions.py
@@ -1,23 +1,26 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: 0BSD
 
-"""Versioned documentation trees for terok-* GitHub Pages sites.
+"""Stateless versioned-docs assembly for terok-* GitHub Pages sites.
 
-Every PyPI release of a terok repo keeps a frozen docs snapshot under
-``/<minor>/`` on the repo's ``gh-pages`` branch, while each master merge
-refreshes ``/dev/``.  The Material version chooser is driven purely by a
-``versions.json`` file at the tree root — the layout contract established
-by `mike <https://github.com/jimporter/mike>`_.  mike itself cannot drive
-ProperDocs builds (it shells out to ``mkdocs``), so this module maintains
-the same tree layout directly: install a freshly built ``site/`` into its
-version directory, upsert the ``versions.json`` entry, re-materialise
-aliases (``latest``), and keep the root redirect aimed at the right
-default.
+Every PyPI release ships its built docs as an immutable release asset
+(``docs-site.tar.gz``); the served site is reassembled from scratch on
+every deploy: the newest final release of each of the last few minors
+plus a fresh ``/dev/`` build, with ``versions.json`` — the contract
+Material's version chooser reads — derived from the release list.
+Nothing is stored between deploys, so there is no ``gh-pages`` branch to
+protect, no history to squash, and a deploy is a pure function of the
+release set and master.
 
-The tree lives on ``gh-pages`` and is pushed by the
-``publish-versioned-docs.yml`` reusable workflow, which runs this module
-from the calling repo's locked docs environment (the same contract as
-[`mkdocs_terok.inventory`][]).
+Retention is an assembly parameter: only the newest *keep* minors are
+served (the chooser and the site plateau instead of growing with the
+release cadence); older versions stay downloadable from their release
+assets forever.
+
+The module is IO-light on purpose: the ``publish-versioned-docs.yml``
+reusable workflow fetches the release list and downloads the snapshot
+tarballs, while the selection and tree-layout logic lives here, where it
+is testable.
 """
 
 from __future__ import annotations
@@ -26,15 +29,13 @@ import argparse
 import json
 import re
 import shutil
-from collections.abc import Sequence
 from pathlib import Path
 
-_VERSIONS_FILE = "versions.json"
+#: Name of the per-release docs snapshot asset.
+DOCS_ASSET = "docs-site.tar.gz"
 
-#: Version and alias names become directory names inside the tree, so they
-#: must be single path components — no separators, no leading dot (which
-#: also rules out ``..``).
-_SAFE_COMPONENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+#: Final releases only — alphas never reach PyPI and mint no docs.
+_FINAL_TAG = re.compile(r"v(\d+)\.(\d+)\.(\d+)")
 
 _ROOT_REDIRECT = """\
 <!DOCTYPE html>
@@ -49,163 +50,113 @@ _ROOT_REDIRECT = """\
 """
 
 
-def deploy(
-    *,
-    site: Path,
-    tree: Path,
-    version: str,
-    title: str | None = None,
-    aliases: Sequence[str] = (),
-) -> None:
-    """Install a built ``site/`` as *version* inside the docs *tree*.
+def plan(releases: list[dict], *, keep: int) -> list[dict]:
+    """Select which release snapshots the served site carries.
 
-    The chooser entry for *version* is created or replaced; any alias in
-    *aliases* is taken over from whichever entry held it before.
+    From the GitHub release list, final ``vX.Y.Z`` releases carrying the
+    docs asset are grouped by minor; the highest patch wins its minor,
+    and the newest *keep* minors survive.
 
     Args:
-        site: Freshly built ProperDocs output directory.
-        tree: Root of the versioned docs tree (a ``gh-pages`` checkout).
-        version: Directory name and chooser identity — a minor release
-            like ``0.8``, or ``dev``.
-        title: Chooser label; releases pass the full version
-            (``0.8.2``).  Defaults to *version*.
-        aliases: Alias directories re-pointed at this version
-            (typically ``latest``).
+        releases: Release objects as returned by the GitHub API
+            (``tag_name``, ``draft``, ``assets[].name`` are consulted).
+        keep: How many minors to serve.
 
-    Raises:
-        ValueError: *version* or an alias is not a plain directory name
-            (path separators, a leading dot, or empty), which would let a
-            crafted CLI argument write outside the tree; or *tree* points
-            at an existing non-empty directory that carries no
-            ``versions.json`` marker (mispointed ``--tree``).
+    Returns:
+        Entries ``{"minor", "tag", "title"}``, newest minor first.
     """
-    _ensure_docs_tree(tree)
-    version_dir = _tree_dir(tree, version)
-    alias_dirs = [_tree_dir(tree, alias) for alias in aliases]
-    entries = _upsert(
-        _load_entries(tree), version=version, title=title or version, aliases=list(aliases)
-    )
-    tree.mkdir(parents=True, exist_ok=True)
-    _replace_dir(site, version_dir)
-    for alias_dir in alias_dirs:
-        _replace_dir(version_dir, alias_dir)
-    (tree / _VERSIONS_FILE).write_text(json.dumps(entries, indent=2) + "\n")
-    (tree / "index.html").write_text(_ROOT_REDIRECT.format(target=_default_target(entries)))
-    (tree / ".nojekyll").touch()
+    best: dict[tuple[int, int], tuple[int, str]] = {}
+    for release in releases:
+        match = _FINAL_TAG.fullmatch(release.get("tag_name", ""))
+        if not match or release.get("draft"):
+            continue
+        if not any(asset.get("name") == DOCS_ASSET for asset in release.get("assets", ())):
+            continue
+        major, minor, patch = (int(part) for part in match.groups())
+        if patch >= best.get((major, minor), (-1, ""))[0]:
+            best[(major, minor)] = (patch, release["tag_name"])
+    newest = sorted(best, reverse=True)[:keep]
+    return [
+        {
+            "minor": f"{major}.{minor}",
+            "tag": best[(major, minor)][1],
+            "title": best[(major, minor)][1].lstrip("v"),
+        }
+        for major, minor in newest
+    ]
 
 
-def _load_entries(tree: Path) -> list[dict]:
-    """Return the chooser entries recorded in *tree*, oldest deploy wins ties."""
-    versions_file = tree / _VERSIONS_FILE
-    if not versions_file.is_file():
-        return []
-    return json.loads(versions_file.read_text())
+def assemble(*, dev_site: Path, snapshots: Path, entries: list[dict], out: Path) -> None:
+    """Lay out the complete site tree for a Pages deploy.
 
-
-def _upsert(entries: list[dict], *, version: str, title: str, aliases: list[str]) -> list[dict]:
-    """Return *entries* with the *version* entry replaced and *aliases* stolen.
-
-    The result is chooser-ordered: ``dev`` first, then releases newest to
-    oldest — the order Material renders verbatim.
+    Args:
+        dev_site: Freshly built ProperDocs output for master.
+        snapshots: Directory holding one unpacked snapshot per served
+            minor (``snapshots/<minor>/``), as planned by
+            [`mkdocs_terok.versions.plan`][].
+        entries: The plan — newest minor first.
+        out: Tree to create; replaced wholesale if it exists.
     """
-    others = [entry for entry in entries if entry["version"] != version]
-    for entry in others:
-        entry["aliases"] = [alias for alias in entry["aliases"] if alias not in aliases]
-    merged = [*others, {"version": version, "title": title, "aliases": aliases}]
-    return sorted(merged, key=lambda entry: _release_key(entry["version"]), reverse=True)
-
-
-def _release_key(version: str) -> tuple[float, ...]:
-    """Sort key placing non-numeric channels (``dev``) above any release."""
-    try:
-        return tuple(float(part) for part in version.split("."))
-    except ValueError:
-        return (float("inf"),)
-
-
-def _default_target(entries: list[dict]) -> str:
-    """Where the tree-root redirect points.
-
-    The latest release when one exists; before the first release, the
-    newest entry there is (``dev``).
-    """
-    if any("latest" in entry["aliases"] for entry in entries):
-        return "latest"
-    return entries[0]["version"] if entries else "dev"
-
-
-def _ensure_docs_tree(tree: Path) -> None:
-    """Refuse to deploy into a directory that isn't a versioned docs tree.
-
-    Deploying replaces version directories wholesale, so a mispointed
-    ``--tree`` (a home directory, a source checkout) must not cost data.
-    Legitimate trees are exactly what the publish workflow produces: a
-    not-yet-existing or empty directory (fresh ``gh-pages`` worktree) or
-    one carrying the ``versions.json`` marker from a previous deploy.
-
-    Raises:
-        ValueError: *tree* exists, is non-empty, and has no marker.
-    """
-    if not tree.exists() or not any(tree.iterdir()) or (tree / _VERSIONS_FILE).is_file():
-        return
-    raise ValueError(f"not a versioned docs tree (non-empty, no {_VERSIONS_FILE}): {tree}")
-
-
-def _tree_dir(tree: Path, name: str) -> Path:
-    """Resolve *name* as a directory directly inside *tree*, or refuse.
-
-    Version and alias names come from CLI arguments and become directory
-    names, so anything that isn't a plain path component (separators, a
-    leading dot — which also rules out ``..``) is rejected, and the
-    resolved path must stay a direct child of the tree.
-
-    Raises:
-        ValueError: *name* would land outside (or on) the tree root.
-    """
-    if not _SAFE_COMPONENT.fullmatch(name):
-        raise ValueError(f"unsafe tree directory name: {name!r}")
-    candidate = (tree / name).resolve()
-    if not candidate.is_relative_to(tree.resolve()) or candidate == tree.resolve():
-        raise ValueError(f"unsafe tree directory name: {name!r}")
-    return candidate
-
-
-def _replace_dir(source: Path, target: Path) -> None:
-    """Copy *source* over *target*, dropping whatever was there before."""
-    if target.exists():
-        shutil.rmtree(target)
-    shutil.copytree(source, target)
+    if out.exists():
+        shutil.rmtree(out)
+    out.mkdir(parents=True)
+    shutil.copytree(dev_site, out / "dev")
+    for entry in entries:
+        shutil.copytree(snapshots / entry["minor"], out / entry["minor"])
+    chooser = [{"version": "dev", "title": "dev", "aliases": []}] + [
+        {
+            "version": entry["minor"],
+            "title": entry["title"],
+            "aliases": ["latest"] if entry is entries[0] else [],
+        }
+        for entry in entries
+    ]
+    (out / "versions.json").write_text(json.dumps(chooser, indent=2) + "\n")
+    target = entries[0]["minor"] if entries else "dev"
+    (out / "index.html").write_text(_ROOT_REDIRECT.format(target=target))
+    (out / ".nojekyll").touch()
 
 
 def _main(argv: list[str] | None = None) -> None:
-    """``python -m mkdocs_terok.versions`` entrypoint."""
+    """``python -m mkdocs_terok.versions`` entrypoint (plan / assemble)."""
     parser = argparse.ArgumentParser(
         prog="python -m mkdocs_terok.versions",
-        description="Install a built docs site into a versioned gh-pages tree.",
+        description="Assemble a versioned docs site from release snapshots plus a dev build.",
     )
-    parser.add_argument("--site", type=Path, required=True, help="Built ProperDocs site directory")
-    parser.add_argument("--tree", type=Path, required=True, help="Root of the versioned docs tree")
-    parser.add_argument(
-        "--version", required=True, help="Version directory and chooser id (e.g. 0.8 or dev)"
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    plan_cmd = commands.add_parser("plan", help="Select served snapshots from the release list")
+    plan_cmd.add_argument(
+        "--releases", type=Path, required=True, help="GitHub API release list (JSON file)"
     )
-    parser.add_argument(
-        "--title", default=None, help="Chooser label (e.g. 0.8.2); defaults to --version"
+    plan_cmd.add_argument(
+        "--keep", type=int, default=6, help="How many newest minors to serve (default: 6)"
     )
-    parser.add_argument(
-        "--alias",
-        action="append",
-        default=[],
-        dest="aliases",
-        help="Alias directory re-pointed at this version (repeatable, e.g. latest)",
+
+    assemble_cmd = commands.add_parser("assemble", help="Lay out the site tree for deploy")
+    assemble_cmd.add_argument(
+        "--dev", type=Path, required=True, help="Built ProperDocs site for master"
     )
+    assemble_cmd.add_argument(
+        "--snapshots", type=Path, required=True, help="Directory of unpacked snapshots per minor"
+    )
+    assemble_cmd.add_argument(
+        "--plan", type=Path, required=True, help="Plan JSON produced by the plan command"
+    )
+    assemble_cmd.add_argument(
+        "--out", type=Path, required=True, help="Tree to create for upload-pages-artifact"
+    )
+
     args = parser.parse_args(argv)
-    deploy(
-        site=args.site,
-        tree=args.tree,
-        version=args.version,
-        title=args.title,
-        aliases=args.aliases,
-    )
+    if args.command == "plan":
+        print(json.dumps(plan(json.loads(args.releases.read_text()), keep=args.keep), indent=2))
+    else:
+        assemble(
+            dev_site=args.dev,
+            snapshots=args.snapshots,
+            entries=json.loads(args.plan.read_text()),
+            out=args.out,
+        )
 
 
 if __name__ == "__main__":

--- a/src/mkdocs_terok/versions.py
+++ b/src/mkdocs_terok/versions.py
@@ -96,7 +96,12 @@ def assemble(*, dev_site: Path, snapshots: Path, entries: list[dict], out: Path)
             [`mkdocs_terok.versions.plan`][].
         entries: The plan — newest minor first.
         out: Tree to create; replaced wholesale if it exists.
+
+    Raises:
+        ValueError: *out* points at an existing non-empty directory that
+            is not a previously assembled tree (mispointed ``--out``).
     """
+    _ensure_replaceable(out)
     if out.exists():
         shutil.rmtree(out)
     out.mkdir(parents=True)
@@ -115,6 +120,22 @@ def assemble(*, dev_site: Path, snapshots: Path, entries: list[dict], out: Path)
     target = entries[0]["minor"] if entries else "dev"
     (out / "index.html").write_text(_ROOT_REDIRECT.format(target=target))
     (out / ".nojekyll").touch()
+
+
+def _ensure_replaceable(out: Path) -> None:
+    """Refuse to wipe a directory that isn't an assembled docs tree.
+
+    Assembly replaces *out* wholesale, so a mispointed ``--out`` (a home
+    directory, a source checkout) must not cost data: the target must be
+    absent, empty (fresh runner temp dir), or carry the
+    ``versions.json`` marker from a previous assembly.
+
+    Raises:
+        ValueError: *out* exists, is non-empty, and has no marker.
+    """
+    if not out.exists() or not any(out.iterdir()) or (out / "versions.json").is_file():
+        return
+    raise ValueError(f"refusing to replace {out}: non-empty and not an assembled docs tree")
 
 
 def _main(argv: list[str] | None = None) -> None:

--- a/src/mkdocs_terok/versions.py
+++ b/src/mkdocs_terok/versions.py
@@ -75,8 +75,11 @@ def deploy(
     Raises:
         ValueError: *version* or an alias is not a plain directory name
             (path separators, a leading dot, or empty), which would let a
-            crafted CLI argument write outside the tree.
+            crafted CLI argument write outside the tree; or *tree* points
+            at an existing non-empty directory that carries no
+            ``versions.json`` marker (mispointed ``--tree``).
     """
+    _ensure_docs_tree(tree)
     version_dir = _tree_dir(tree, version)
     alias_dirs = [_tree_dir(tree, alias) for alias in aliases]
     entries = _upsert(
@@ -129,6 +132,23 @@ def _default_target(entries: list[dict]) -> str:
     if any("latest" in entry["aliases"] for entry in entries):
         return "latest"
     return entries[0]["version"] if entries else "dev"
+
+
+def _ensure_docs_tree(tree: Path) -> None:
+    """Refuse to deploy into a directory that isn't a versioned docs tree.
+
+    Deploying replaces version directories wholesale, so a mispointed
+    ``--tree`` (a home directory, a source checkout) must not cost data.
+    Legitimate trees are exactly what the publish workflow produces: a
+    not-yet-existing or empty directory (fresh ``gh-pages`` worktree) or
+    one carrying the ``versions.json`` marker from a previous deploy.
+
+    Raises:
+        ValueError: *tree* exists, is non-empty, and has no marker.
+    """
+    if not tree.exists() or not any(tree.iterdir()) or (tree / _VERSIONS_FILE).is_file():
+        return
+    raise ValueError(f"not a versioned docs tree (non-empty, no {_VERSIONS_FILE}): {tree}")
 
 
 def _tree_dir(tree: Path, name: str) -> Path:

--- a/src/mkdocs_terok/versions.py
+++ b/src/mkdocs_terok/versions.py
@@ -77,16 +77,15 @@ def deploy(
             (path separators, a leading dot, or empty), which would let a
             crafted CLI argument write outside the tree.
     """
-    for name in (version, *aliases):
-        if not _SAFE_COMPONENT.fullmatch(name):
-            raise ValueError(f"unsafe tree directory name: {name!r}")
+    version_dir = _tree_dir(tree, version)
+    alias_dirs = [_tree_dir(tree, alias) for alias in aliases]
     entries = _upsert(
         _load_entries(tree), version=version, title=title or version, aliases=list(aliases)
     )
     tree.mkdir(parents=True, exist_ok=True)
-    _replace_dir(site, tree / version)
-    for alias in aliases:
-        _replace_dir(tree / version, tree / alias)
+    _replace_dir(site, version_dir)
+    for alias_dir in alias_dirs:
+        _replace_dir(version_dir, alias_dir)
     (tree / _VERSIONS_FILE).write_text(json.dumps(entries, indent=2) + "\n")
     (tree / "index.html").write_text(_ROOT_REDIRECT.format(target=_default_target(entries)))
     (tree / ".nojekyll").touch()
@@ -130,6 +129,25 @@ def _default_target(entries: list[dict]) -> str:
     if any("latest" in entry["aliases"] for entry in entries):
         return "latest"
     return entries[0]["version"] if entries else "dev"
+
+
+def _tree_dir(tree: Path, name: str) -> Path:
+    """Resolve *name* as a directory directly inside *tree*, or refuse.
+
+    Version and alias names come from CLI arguments and become directory
+    names, so anything that isn't a plain path component (separators, a
+    leading dot — which also rules out ``..``) is rejected, and the
+    resolved path must stay a direct child of the tree.
+
+    Raises:
+        ValueError: *name* would land outside (or on) the tree root.
+    """
+    if not _SAFE_COMPONENT.fullmatch(name):
+        raise ValueError(f"unsafe tree directory name: {name!r}")
+    candidate = (tree / name).resolve()
+    if not candidate.is_relative_to(tree.resolve()) or candidate == tree.resolve():
+        raise ValueError(f"unsafe tree directory name: {name!r}")
+    return candidate
 
 
 def _replace_dir(source: Path, target: Path) -> None:

--- a/src/mkdocs_terok/versions.py
+++ b/src/mkdocs_terok/versions.py
@@ -63,7 +63,7 @@ def plan(releases: list[dict], *, keep: int) -> list[dict]:
         keep: How many minors to serve.
 
     Returns:
-        Entries ``{"minor", "tag", "title"}``, newest minor first.
+        Entries ``{"minor", "tag"}``, newest minor first.
     """
     best: dict[tuple[int, int], tuple[int, str]] = {}
     for release in releases:
@@ -77,17 +77,16 @@ def plan(releases: list[dict], *, keep: int) -> list[dict]:
             best[(major, minor)] = (patch, release["tag_name"])
     newest = sorted(best, reverse=True)[:keep]
     return [
-        {
-            "minor": f"{major}.{minor}",
-            "tag": best[(major, minor)][1],
-            "title": best[(major, minor)][1].lstrip("v"),
-        }
-        for major, minor in newest
+        {"minor": f"{major}.{minor}", "tag": best[(major, minor)][1]} for major, minor in newest
     ]
 
 
 def assemble(*, dev_site: Path, snapshots: Path, entries: list[dict], out: Path) -> None:
     """Lay out the complete site tree for a Pages deploy.
+
+    Consumes its inputs: *dev_site* and the snapshot directories are
+    moved into the tree, not copied — they are per-run scratch extracts,
+    and a copy would double the whole served site on the deploy path.
 
     Args:
         dev_site: Freshly built ProperDocs output for master.
@@ -105,13 +104,13 @@ def assemble(*, dev_site: Path, snapshots: Path, entries: list[dict], out: Path)
     if out.exists():
         shutil.rmtree(out)
     out.mkdir(parents=True)
-    shutil.copytree(dev_site, out / "dev")
+    shutil.move(dev_site, out / "dev")
     for entry in entries:
-        shutil.copytree(snapshots / entry["minor"], out / entry["minor"])
+        shutil.move(snapshots / entry["minor"], out / entry["minor"])
     chooser = [{"version": "dev", "title": "dev", "aliases": []}] + [
         {
             "version": entry["minor"],
-            "title": entry["title"],
+            "title": entry["tag"].lstrip("v"),
             "aliases": ["latest"] if entry is entries[0] else [],
         }
         for entry in entries

--- a/src/mkdocs_terok/versions.py
+++ b/src/mkdocs_terok/versions.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: 0BSD
+
+"""Versioned documentation trees for terok-* GitHub Pages sites.
+
+Every PyPI release of a terok repo keeps a frozen docs snapshot under
+``/<minor>/`` on the repo's ``gh-pages`` branch, while each master merge
+refreshes ``/dev/``.  The Material version chooser is driven purely by a
+``versions.json`` file at the tree root — the layout contract established
+by `mike <https://github.com/jimporter/mike>`_.  mike itself cannot drive
+ProperDocs builds (it shells out to ``mkdocs``), so this module maintains
+the same tree layout directly: install a freshly built ``site/`` into its
+version directory, upsert the ``versions.json`` entry, re-materialise
+aliases (``latest``), and keep the root redirect aimed at the right
+default.
+
+The tree lives on ``gh-pages`` and is pushed by the
+``publish-versioned-docs.yml`` reusable workflow, which runs this module
+from the calling repo's locked docs environment (the same contract as
+[`mkdocs_terok.inventory`][]).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from collections.abc import Sequence
+from pathlib import Path
+
+_VERSIONS_FILE = "versions.json"
+
+_ROOT_REDIRECT = """\
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="refresh" content="0; url={target}/">
+<link rel="canonical" href="{target}/">
+<title>Redirecting…</title>
+</head>
+<body>Redirecting to <a href="{target}/">{target}</a>…</body>
+</html>
+"""
+
+
+def deploy(
+    *,
+    site: Path,
+    tree: Path,
+    version: str,
+    title: str | None = None,
+    aliases: Sequence[str] = (),
+) -> None:
+    """Install a built ``site/`` as *version* inside the docs *tree*.
+
+    The chooser entry for *version* is created or replaced; any alias in
+    *aliases* is taken over from whichever entry held it before.
+
+    Args:
+        site: Freshly built ProperDocs output directory.
+        tree: Root of the versioned docs tree (a ``gh-pages`` checkout).
+        version: Directory name and chooser identity — a minor release
+            like ``0.8``, or ``dev``.
+        title: Chooser label; releases pass the full version
+            (``0.8.2``).  Defaults to *version*.
+        aliases: Alias directories re-pointed at this version
+            (typically ``latest``).
+    """
+    entries = _upsert(
+        _load_entries(tree), version=version, title=title or version, aliases=list(aliases)
+    )
+    tree.mkdir(parents=True, exist_ok=True)
+    _replace_dir(site, tree / version)
+    for alias in aliases:
+        _replace_dir(tree / version, tree / alias)
+    (tree / _VERSIONS_FILE).write_text(json.dumps(entries, indent=2) + "\n")
+    (tree / "index.html").write_text(_ROOT_REDIRECT.format(target=_default_target(entries)))
+    (tree / ".nojekyll").touch()
+
+
+def _load_entries(tree: Path) -> list[dict]:
+    """Return the chooser entries recorded in *tree*, oldest deploy wins ties."""
+    versions_file = tree / _VERSIONS_FILE
+    if not versions_file.is_file():
+        return []
+    return json.loads(versions_file.read_text())
+
+
+def _upsert(entries: list[dict], *, version: str, title: str, aliases: list[str]) -> list[dict]:
+    """Return *entries* with the *version* entry replaced and *aliases* stolen.
+
+    The result is chooser-ordered: ``dev`` first, then releases newest to
+    oldest — the order Material renders verbatim.
+    """
+    others = [entry for entry in entries if entry["version"] != version]
+    for entry in others:
+        entry["aliases"] = [alias for alias in entry["aliases"] if alias not in aliases]
+    merged = [*others, {"version": version, "title": title, "aliases": aliases}]
+    return sorted(merged, key=lambda entry: _release_key(entry["version"]), reverse=True)
+
+
+def _release_key(version: str) -> tuple[float, ...]:
+    """Sort key placing non-numeric channels (``dev``) above any release."""
+    try:
+        return tuple(float(part) for part in version.split("."))
+    except ValueError:
+        return (float("inf"),)
+
+
+def _default_target(entries: list[dict]) -> str:
+    """Where the tree-root redirect points.
+
+    The latest release when one exists; before the first release, the
+    newest entry there is (``dev``).
+    """
+    if any("latest" in entry["aliases"] for entry in entries):
+        return "latest"
+    return entries[0]["version"] if entries else "dev"
+
+
+def _replace_dir(source: Path, target: Path) -> None:
+    """Copy *source* over *target*, dropping whatever was there before."""
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(source, target)
+
+
+def _main(argv: list[str] | None = None) -> None:
+    """``python -m mkdocs_terok.versions`` entrypoint."""
+    parser = argparse.ArgumentParser(
+        prog="python -m mkdocs_terok.versions",
+        description="Install a built docs site into a versioned gh-pages tree.",
+    )
+    parser.add_argument("--site", type=Path, required=True, help="Built ProperDocs site directory")
+    parser.add_argument("--tree", type=Path, required=True, help="Root of the versioned docs tree")
+    parser.add_argument(
+        "--version", required=True, help="Version directory and chooser id (e.g. 0.8 or dev)"
+    )
+    parser.add_argument(
+        "--title", default=None, help="Chooser label (e.g. 0.8.2); defaults to --version"
+    )
+    parser.add_argument(
+        "--alias",
+        action="append",
+        default=[],
+        dest="aliases",
+        help="Alias directory re-pointed at this version (repeatable, e.g. latest)",
+    )
+    args = parser.parse_args(argv)
+    deploy(
+        site=args.site,
+        tree=args.tree,
+        version=args.version,
+        title=args.title,
+        aliases=args.aliases,
+    )
+
+
+if __name__ == "__main__":
+    _main()

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -71,6 +71,27 @@ class TestStripSiblingInventoryLines:
         """)
         assert _strip_sibling_inventory_lines(text) == text
 
+    def test_strips_flow_mapping_entries(self) -> None:
+        """``- { url: ..., base_url: ... }`` sibling entries disappear whole."""
+        text = textwrap.dedent("""\
+            inventories:
+              - https://docs.python.org/3/objects.inv
+              - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-sandbox/objects.inv", base_url: "https://terok-ai.github.io/terok-sandbox/" }
+              - { url: !ENV [TEROK_INV_UTIL_URL, "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-util/objects.inv"], base_url: "https://terok-ai.github.io/terok-util/dev/" }
+        """)
+        out = _strip_sibling_inventory_lines(text)
+        assert "docs.python.org" in out
+        assert "terok-sandbox" not in out
+        assert "terok-util" not in out
+
+    def test_preserves_non_sibling_flow_mappings(self) -> None:
+        """Flow-mapping entries for third-party inventories survive."""
+        text = textwrap.dedent("""\
+            inventories:
+              - { url: "https://docs.pydantic.dev/latest/objects.inv", domains: [py] }
+        """)
+        assert _strip_sibling_inventory_lines(text) == text
+
     def test_preserves_trailing_newline(self) -> None:
         """A trailing newline survives the round-trip (mkdocs is fussy)."""
         text = "key: value\n"

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -83,6 +83,15 @@ class TestDeploy:
         assert [entry["title"] for entry in _entries(tree)] == ["0.8.1"]
         assert (tree / "0.8" / "index.html").read_text() == "<h1>0.8.1 docs</h1>"
 
+    @pytest.mark.parametrize("name", ["../escape", "a/b", "..", ".hidden", ""])
+    def test_rejects_unsafe_directory_names(self, site: Path, tmp_path: Path, name: str) -> None:
+        """Version and alias names must be plain directory names — no traversal."""
+        tree = tmp_path / "tree"
+        with pytest.raises(ValueError, match="unsafe tree directory name"):
+            deploy(site=site, tree=tree, version=name)
+        with pytest.raises(ValueError, match="unsafe tree directory name"):
+            deploy(site=site, tree=tree, version="0.8", aliases=[name])
+
     def test_stale_version_files_are_dropped(self, site: Path, tmp_path: Path) -> None:
         """Redeploying a version removes files the new build no longer produces."""
         tree = tmp_path / "tree"

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: 0BSD
 
-"""Tests for the versioned docs tree maintainer."""
+"""Tests for the stateless versioned-docs assembler."""
 
 from __future__ import annotations
 
@@ -10,129 +10,132 @@ from pathlib import Path
 
 import pytest
 
-from mkdocs_terok.versions import _main, deploy
+from mkdocs_terok.versions import DOCS_ASSET, _main, assemble, plan
 
 
-@pytest.fixture
-def site(tmp_path: Path) -> Path:
-    """A minimal built site: an index page and a nested asset."""
-    built = tmp_path / "site"
-    (built / "assets").mkdir(parents=True)
-    (built / "index.html").write_text("<h1>built docs</h1>")
-    (built / "assets" / "extra.css").write_text("body {}")
-    return built
+def _release(tag: str, *, draft: bool = False, with_asset: bool = True) -> dict:
+    assets = [{"name": DOCS_ASSET}] if with_asset else []
+    return {"tag_name": tag, "draft": draft, "assets": assets}
 
 
-def _entries(tree: Path) -> list[dict]:
-    return json.loads((tree / "versions.json").read_text())
+class TestPlan:
+    """Verify snapshot selection from the GitHub release list."""
+
+    def test_newest_patch_wins_its_minor(self) -> None:
+        """Within one minor, only the highest patch is served."""
+        entries = plan([_release("v0.8.0"), _release("v0.8.2"), _release("v0.8.1")], keep=6)
+        assert entries == [{"minor": "0.8", "tag": "v0.8.2", "title": "0.8.2"}]
+
+    def test_minors_are_newest_first_and_capped(self) -> None:
+        """Retention keeps only the newest *keep* minors, newest first."""
+        releases = [_release(f"v0.{m}.0") for m in (7, 10, 8, 9)]
+        entries = plan(releases, keep=2)
+        assert [entry["minor"] for entry in entries] == ["0.10", "0.9"]
+
+    def test_ignores_alphas_drafts_and_assetless_releases(self) -> None:
+        """Only final, published releases carrying the docs asset qualify."""
+        releases = [
+            _release("v0.9.0a1"),
+            _release("v0.9.0", draft=True),
+            _release("v0.8.0", with_asset=False),
+            _release("v0.7.3"),
+        ]
+        assert [entry["tag"] for entry in plan(releases, keep=6)] == ["v0.7.3"]
+
+    def test_empty_release_list(self) -> None:
+        """Before the first release there is nothing to serve."""
+        assert plan([], keep=6) == []
 
 
-class TestDeploy:
-    """Verify the gh-pages tree layout after deploys."""
+class TestAssemble:
+    """Verify the deployed tree layout."""
 
-    def test_first_dev_deploy_creates_tree(self, site: Path, tmp_path: Path) -> None:
-        """A dev deploy into an empty tree yields dev/, versions.json and a dev redirect."""
-        tree = tmp_path / "tree"
-        deploy(site=site, tree=tree, version="dev")
+    @pytest.fixture
+    def dev_site(self, tmp_path: Path) -> Path:
+        """A minimal dev build."""
+        built = tmp_path / "dev-site"
+        built.mkdir()
+        (built / "index.html").write_text("<h1>dev docs</h1>")
+        return built
 
-        assert (tree / "dev" / "index.html").read_text() == "<h1>built docs</h1>"
-        assert (tree / "dev" / "assets" / "extra.css").is_file()
-        assert _entries(tree) == [{"version": "dev", "title": "dev", "aliases": []}]
-        assert "url=dev/" in (tree / "index.html").read_text()
-        assert (tree / ".nojekyll").is_file()
+    @pytest.fixture
+    def snapshots(self, tmp_path: Path) -> Path:
+        """Unpacked snapshots for minors 0.9 and 0.8."""
+        root = tmp_path / "snapshots"
+        for minor in ("0.9", "0.8"):
+            (root / minor).mkdir(parents=True)
+            (root / minor / "index.html").write_text(f"<h1>{minor} docs</h1>")
+        return root
 
-    def test_release_takes_over_root_redirect(self, site: Path, tmp_path: Path) -> None:
-        """Once a release holds the latest alias, the root redirect leaves dev."""
-        tree = tmp_path / "tree"
-        deploy(site=site, tree=tree, version="dev")
-        deploy(site=site, tree=tree, version="0.8", title="0.8.0", aliases=["latest"])
+    def test_tree_layout_and_chooser(self, dev_site: Path, snapshots: Path, tmp_path: Path) -> None:
+        """dev + served minors land in the tree; chooser is dev-first with latest label."""
+        out = tmp_path / "tree"
+        entries = [
+            {"minor": "0.9", "tag": "v0.9.1", "title": "0.9.1"},
+            {"minor": "0.8", "tag": "v0.8.2", "title": "0.8.2"},
+        ]
+        assemble(dev_site=dev_site, snapshots=snapshots, entries=entries, out=out)
 
-        assert (tree / "0.8" / "index.html").is_file()
-        assert (tree / "latest" / "index.html").is_file()
-        assert "url=latest/" in (tree / "index.html").read_text()
+        assert (out / "dev" / "index.html").read_text() == "<h1>dev docs</h1>"
+        assert (out / "0.9" / "index.html").read_text() == "<h1>0.9 docs</h1>"
+        assert (out / "0.8" / "index.html").read_text() == "<h1>0.8 docs</h1>"
+        assert json.loads((out / "versions.json").read_text()) == [
+            {"version": "dev", "title": "dev", "aliases": []},
+            {"version": "0.9", "title": "0.9.1", "aliases": ["latest"]},
+            {"version": "0.8", "title": "0.8.2", "aliases": []},
+        ]
+        assert "url=0.9/" in (out / "index.html").read_text()
+        assert (out / ".nojekyll").is_file()
 
-    def test_chooser_order_is_dev_then_newest(self, site: Path, tmp_path: Path) -> None:
-        """Entries render dev first, then releases newest to oldest."""
-        tree = tmp_path / "tree"
-        deploy(site=site, tree=tree, version="0.8", title="0.8.2", aliases=["latest"])
-        deploy(site=site, tree=tree, version="0.10", title="0.10.0", aliases=["latest"])
-        deploy(site=site, tree=tree, version="0.9", title="0.9.1")
-        deploy(site=site, tree=tree, version="dev")
+    def test_no_releases_serves_dev_only(self, dev_site: Path, tmp_path: Path) -> None:
+        """Before the first release the root redirect points at dev."""
+        out = tmp_path / "tree"
+        assemble(dev_site=dev_site, snapshots=tmp_path / "none", entries=[], out=out)
 
-        assert [entry["version"] for entry in _entries(tree)] == ["dev", "0.10", "0.9", "0.8"]
+        assert "url=dev/" in (out / "index.html").read_text()
+        assert [e["version"] for e in json.loads((out / "versions.json").read_text())] == ["dev"]
 
-    def test_alias_is_stolen_from_previous_release(self, site: Path, tmp_path: Path) -> None:
-        """Deploying a newer release moves the latest alias entry and directory."""
-        tree = tmp_path / "tree"
-        deploy(site=site, tree=tree, version="0.8", title="0.8.0", aliases=["latest"])
-        (site / "index.html").write_text("<h1>0.9 docs</h1>")
-        deploy(site=site, tree=tree, version="0.9", title="0.9.0", aliases=["latest"])
+    def test_reassembly_replaces_previous_tree(
+        self, dev_site: Path, snapshots: Path, tmp_path: Path
+    ) -> None:
+        """A deploy is a pure function of its inputs — stale content vanishes."""
+        out = tmp_path / "tree"
+        entries = [{"minor": "0.9", "tag": "v0.9.1", "title": "0.9.1"}]
+        assemble(dev_site=dev_site, snapshots=snapshots, entries=entries, out=out)
+        assemble(dev_site=dev_site, snapshots=snapshots, entries=[], out=out)
 
-        by_version = {entry["version"]: entry for entry in _entries(tree)}
-        assert by_version["0.8"]["aliases"] == []
-        assert by_version["0.9"]["aliases"] == ["latest"]
-        assert (tree / "latest" / "index.html").read_text() == "<h1>0.9 docs</h1>"
-
-    def test_patch_redeploy_replaces_minor_in_place(self, site: Path, tmp_path: Path) -> None:
-        """A patch release refreshes its minor directory and chooser title."""
-        tree = tmp_path / "tree"
-        deploy(site=site, tree=tree, version="0.8", title="0.8.0", aliases=["latest"])
-        (site / "index.html").write_text("<h1>0.8.1 docs</h1>")
-        deploy(site=site, tree=tree, version="0.8", title="0.8.1", aliases=["latest"])
-
-        assert [entry["title"] for entry in _entries(tree)] == ["0.8.1"]
-        assert (tree / "0.8" / "index.html").read_text() == "<h1>0.8.1 docs</h1>"
-
-    @pytest.mark.parametrize("name", ["../escape", "a/b", "..", ".hidden", ""])
-    def test_rejects_unsafe_directory_names(self, site: Path, tmp_path: Path, name: str) -> None:
-        """Version and alias names must be plain directory names — no traversal."""
-        tree = tmp_path / "tree"
-        with pytest.raises(ValueError, match="unsafe tree directory name"):
-            deploy(site=site, tree=tree, version=name)
-        with pytest.raises(ValueError, match="unsafe tree directory name"):
-            deploy(site=site, tree=tree, version="0.8", aliases=[name])
-
-    def test_refuses_a_tree_that_is_not_a_docs_tree(self, site: Path, tmp_path: Path) -> None:
-        """A non-empty --tree without the versions.json marker must not be touched."""
-        not_a_tree = tmp_path / "home"
-        (not_a_tree / "Documents").mkdir(parents=True)
-        (not_a_tree / "Documents" / "thesis.txt").write_text("precious")
-
-        with pytest.raises(ValueError, match="not a versioned docs tree"):
-            deploy(site=site, tree=not_a_tree, version="Documents")
-
-        assert (not_a_tree / "Documents" / "thesis.txt").read_text() == "precious"
-
-    def test_stale_version_files_are_dropped(self, site: Path, tmp_path: Path) -> None:
-        """Redeploying a version removes files the new build no longer produces."""
-        tree = tmp_path / "tree"
-        deploy(site=site, tree=tree, version="dev")
-        (site / "assets" / "extra.css").unlink()
-        deploy(site=site, tree=tree, version="dev")
-
-        assert not (tree / "dev" / "assets" / "extra.css").exists()
+        assert not (out / "0.9").exists()
 
 
 class TestMain:
-    """Verify the module CLI drives a deploy."""
+    """Verify the two-command CLI round-trip."""
 
-    def test_cli_deploys_with_alias(self, site: Path, tmp_path: Path) -> None:
-        """The argparse front-end forwards site, tree, version, title and aliases."""
-        tree = tmp_path / "tree"
+    def test_plan_then_assemble(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """plan output feeds assemble unchanged."""
+        releases = tmp_path / "releases.json"
+        releases.write_text(json.dumps([_release("v0.8.1"), _release("v0.8.0")]))
+        _main(["plan", "--releases", str(releases), "--keep", "3"])
+        plan_json = capsys.readouterr().out
+        assert json.loads(plan_json) == [{"minor": "0.8", "tag": "v0.8.1", "title": "0.8.1"}]
+
+        dev = tmp_path / "site"
+        dev.mkdir()
+        (dev / "index.html").write_text("dev")
+        (tmp_path / "snapshots" / "0.8").mkdir(parents=True)
+        (tmp_path / "snapshots" / "0.8" / "index.html").write_text("0.8")
+        plan_file = tmp_path / "plan.json"
+        plan_file.write_text(plan_json)
         _main(
             [
-                "--site",
-                str(site),
-                "--tree",
-                str(tree),
-                "--version",
-                "0.8",
-                "--title",
-                "0.8.2",
-                "--alias",
-                "latest",
+                "assemble",
+                "--dev",
+                str(dev),
+                "--snapshots",
+                str(tmp_path / "snapshots"),
+                "--plan",
+                str(plan_file),
+                "--out",
+                str(tmp_path / "tree"),
             ]
         )
-
-        assert _entries(tree) == [{"version": "0.8", "title": "0.8.2", "aliases": ["latest"]}]
-        assert (tree / "latest" / "index.html").is_file()
+        assert (tmp_path / "tree" / "0.8" / "index.html").read_text() == "0.8"

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -95,6 +95,15 @@ class TestAssemble:
         assert "url=dev/" in (out / "index.html").read_text()
         assert [e["version"] for e in json.loads((out / "versions.json").read_text())] == ["dev"]
 
+    @pytest.mark.parametrize("minor", ["../escape", "a/b", "..", "0.9x", ""])
+    def test_rejects_unsafe_minor_in_plan(self, dev_site: Path, tmp_path: Path, minor: str) -> None:
+        """A hand-crafted --plan must not steer moves outside the tree."""
+        entries = [{"minor": minor, "tag": "v0.9.0"}]
+        with pytest.raises(ValueError, match="unsafe minor in plan"):
+            assemble(
+                dev_site=dev_site, snapshots=tmp_path / "none", entries=entries, out=tmp_path / "t"
+            )
+
     def test_refuses_out_that_is_not_an_assembled_tree(
         self, dev_site: Path, tmp_path: Path
     ) -> None:

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -95,6 +95,19 @@ class TestAssemble:
         assert "url=dev/" in (out / "index.html").read_text()
         assert [e["version"] for e in json.loads((out / "versions.json").read_text())] == ["dev"]
 
+    def test_refuses_out_that_is_not_an_assembled_tree(
+        self, dev_site: Path, tmp_path: Path
+    ) -> None:
+        """A non-empty --out without the versions.json marker must not be wiped."""
+        precious = tmp_path / "home"
+        (precious / "Documents").mkdir(parents=True)
+        (precious / "Documents" / "thesis.txt").write_text("precious")
+
+        with pytest.raises(ValueError, match="not an assembled docs tree"):
+            assemble(dev_site=dev_site, snapshots=tmp_path / "none", entries=[], out=precious)
+
+        assert (precious / "Documents" / "thesis.txt").read_text() == "precious"
+
     def test_reassembly_replaces_previous_tree(
         self, dev_site: Path, snapshots: Path, tmp_path: Path
     ) -> None:

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: 0BSD
+
+"""Tests for the versioned docs tree maintainer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mkdocs_terok.versions import _main, deploy
+
+
+@pytest.fixture
+def site(tmp_path: Path) -> Path:
+    """A minimal built site: an index page and a nested asset."""
+    built = tmp_path / "site"
+    (built / "assets").mkdir(parents=True)
+    (built / "index.html").write_text("<h1>built docs</h1>")
+    (built / "assets" / "extra.css").write_text("body {}")
+    return built
+
+
+def _entries(tree: Path) -> list[dict]:
+    return json.loads((tree / "versions.json").read_text())
+
+
+class TestDeploy:
+    """Verify the gh-pages tree layout after deploys."""
+
+    def test_first_dev_deploy_creates_tree(self, site: Path, tmp_path: Path) -> None:
+        """A dev deploy into an empty tree yields dev/, versions.json and a dev redirect."""
+        tree = tmp_path / "tree"
+        deploy(site=site, tree=tree, version="dev")
+
+        assert (tree / "dev" / "index.html").read_text() == "<h1>built docs</h1>"
+        assert (tree / "dev" / "assets" / "extra.css").is_file()
+        assert _entries(tree) == [{"version": "dev", "title": "dev", "aliases": []}]
+        assert "url=dev/" in (tree / "index.html").read_text()
+        assert (tree / ".nojekyll").is_file()
+
+    def test_release_takes_over_root_redirect(self, site: Path, tmp_path: Path) -> None:
+        """Once a release holds the latest alias, the root redirect leaves dev."""
+        tree = tmp_path / "tree"
+        deploy(site=site, tree=tree, version="dev")
+        deploy(site=site, tree=tree, version="0.8", title="0.8.0", aliases=["latest"])
+
+        assert (tree / "0.8" / "index.html").is_file()
+        assert (tree / "latest" / "index.html").is_file()
+        assert "url=latest/" in (tree / "index.html").read_text()
+
+    def test_chooser_order_is_dev_then_newest(self, site: Path, tmp_path: Path) -> None:
+        """Entries render dev first, then releases newest to oldest."""
+        tree = tmp_path / "tree"
+        deploy(site=site, tree=tree, version="0.8", title="0.8.2", aliases=["latest"])
+        deploy(site=site, tree=tree, version="0.10", title="0.10.0", aliases=["latest"])
+        deploy(site=site, tree=tree, version="0.9", title="0.9.1")
+        deploy(site=site, tree=tree, version="dev")
+
+        assert [entry["version"] for entry in _entries(tree)] == ["dev", "0.10", "0.9", "0.8"]
+
+    def test_alias_is_stolen_from_previous_release(self, site: Path, tmp_path: Path) -> None:
+        """Deploying a newer release moves the latest alias entry and directory."""
+        tree = tmp_path / "tree"
+        deploy(site=site, tree=tree, version="0.8", title="0.8.0", aliases=["latest"])
+        (site / "index.html").write_text("<h1>0.9 docs</h1>")
+        deploy(site=site, tree=tree, version="0.9", title="0.9.0", aliases=["latest"])
+
+        by_version = {entry["version"]: entry for entry in _entries(tree)}
+        assert by_version["0.8"]["aliases"] == []
+        assert by_version["0.9"]["aliases"] == ["latest"]
+        assert (tree / "latest" / "index.html").read_text() == "<h1>0.9 docs</h1>"
+
+    def test_patch_redeploy_replaces_minor_in_place(self, site: Path, tmp_path: Path) -> None:
+        """A patch release refreshes its minor directory and chooser title."""
+        tree = tmp_path / "tree"
+        deploy(site=site, tree=tree, version="0.8", title="0.8.0", aliases=["latest"])
+        (site / "index.html").write_text("<h1>0.8.1 docs</h1>")
+        deploy(site=site, tree=tree, version="0.8", title="0.8.1", aliases=["latest"])
+
+        assert [entry["title"] for entry in _entries(tree)] == ["0.8.1"]
+        assert (tree / "0.8" / "index.html").read_text() == "<h1>0.8.1 docs</h1>"
+
+    def test_stale_version_files_are_dropped(self, site: Path, tmp_path: Path) -> None:
+        """Redeploying a version removes files the new build no longer produces."""
+        tree = tmp_path / "tree"
+        deploy(site=site, tree=tree, version="dev")
+        (site / "assets" / "extra.css").unlink()
+        deploy(site=site, tree=tree, version="dev")
+
+        assert not (tree / "dev" / "assets" / "extra.css").exists()
+
+
+class TestMain:
+    """Verify the module CLI drives a deploy."""
+
+    def test_cli_deploys_with_alias(self, site: Path, tmp_path: Path) -> None:
+        """The argparse front-end forwards site, tree, version, title and aliases."""
+        tree = tmp_path / "tree"
+        _main(
+            [
+                "--site",
+                str(site),
+                "--tree",
+                str(tree),
+                "--version",
+                "0.8",
+                "--title",
+                "0.8.2",
+                "--alias",
+                "latest",
+            ]
+        )
+
+        assert _entries(tree) == [{"version": "0.8", "title": "0.8.2", "aliases": ["latest"]}]
+        assert (tree / "latest" / "index.html").is_file()

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -24,7 +24,7 @@ class TestPlan:
     def test_newest_patch_wins_its_minor(self) -> None:
         """Within one minor, only the highest patch is served."""
         entries = plan([_release("v0.8.0"), _release("v0.8.2"), _release("v0.8.1")], keep=6)
-        assert entries == [{"minor": "0.8", "tag": "v0.8.2", "title": "0.8.2"}]
+        assert entries == [{"minor": "0.8", "tag": "v0.8.2"}]
 
     def test_minors_are_newest_first_and_capped(self) -> None:
         """Retention keeps only the newest *keep* minors, newest first."""
@@ -71,8 +71,8 @@ class TestAssemble:
         """dev + served minors land in the tree; chooser is dev-first with latest label."""
         out = tmp_path / "tree"
         entries = [
-            {"minor": "0.9", "tag": "v0.9.1", "title": "0.9.1"},
-            {"minor": "0.8", "tag": "v0.8.2", "title": "0.8.2"},
+            {"minor": "0.9", "tag": "v0.9.1"},
+            {"minor": "0.8", "tag": "v0.8.2"},
         ]
         assemble(dev_site=dev_site, snapshots=snapshots, entries=entries, out=out)
 
@@ -113,9 +113,13 @@ class TestAssemble:
     ) -> None:
         """A deploy is a pure function of its inputs — stale content vanishes."""
         out = tmp_path / "tree"
-        entries = [{"minor": "0.9", "tag": "v0.9.1", "title": "0.9.1"}]
+        entries = [{"minor": "0.9", "tag": "v0.9.1"}]
         assemble(dev_site=dev_site, snapshots=snapshots, entries=entries, out=out)
-        assemble(dev_site=dev_site, snapshots=snapshots, entries=[], out=out)
+
+        fresh_dev = tmp_path / "fresh-dev"
+        fresh_dev.mkdir()
+        (fresh_dev / "index.html").write_text("<h1>fresh dev</h1>")
+        assemble(dev_site=fresh_dev, snapshots=snapshots, entries=[], out=out)
 
         assert not (out / "0.9").exists()
 
@@ -129,7 +133,7 @@ class TestMain:
         releases.write_text(json.dumps([_release("v0.8.1"), _release("v0.8.0")]))
         _main(["plan", "--releases", str(releases), "--keep", "3"])
         plan_json = capsys.readouterr().out
-        assert json.loads(plan_json) == [{"minor": "0.8", "tag": "v0.8.1", "title": "0.8.1"}]
+        assert json.loads(plan_json) == [{"minor": "0.8", "tag": "v0.8.1"}]
 
         dev = tmp_path / "site"
         dev.mkdir()

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -92,6 +92,17 @@ class TestDeploy:
         with pytest.raises(ValueError, match="unsafe tree directory name"):
             deploy(site=site, tree=tree, version="0.8", aliases=[name])
 
+    def test_refuses_a_tree_that_is_not_a_docs_tree(self, site: Path, tmp_path: Path) -> None:
+        """A non-empty --tree without the versions.json marker must not be touched."""
+        not_a_tree = tmp_path / "home"
+        (not_a_tree / "Documents").mkdir(parents=True)
+        (not_a_tree / "Documents" / "thesis.txt").write_text("precious")
+
+        with pytest.raises(ValueError, match="not a versioned docs tree"):
+            deploy(site=site, tree=not_a_tree, version="Documents")
+
+        assert (not_a_tree / "Documents" / "thesis.txt").read_text() == "precious"
+
     def test_stale_version_files_are_dropped(self, site: Path, tmp_path: Path) -> None:
         """Redeploying a version removes files the new build no longer produces."""
         tree = tmp_path / "tree"


### PR DESCRIPTION
## What

Machinery for per-release documentation on GitHub Pages, so users landing from a PyPI install see docs matching their version (Material version chooser to switch). **Stateless model** — no gh-pages branch:

- Each PyPI release ships its built site as an immutable release asset (`docs-site.tar.gz`, attached by the repo's release flow).
- Every deploy reassembles the served tree from scratch: newest final release of each of the last `keep` minors (default 6) + fresh `/dev/` build, with `versions.json` **derived from the release list**, then ships it through the standard `upload-pages-artifact`/`deploy-pages` flow.
- A deploy is a pure function of the release set and master: nothing persists between deploys, no branch to protect, no history to squash, no clone bloat; a botched deploy is fixed by re-running. Retention is a parameter, so the served site plateaus (~`keep` × snapshot size) regardless of release cadence; older versions stay downloadable from their release assets forever. Alphas exclude themselves (no PyPI publish → no docs asset).
- `latest` is a chooser label + root redirect to the newest minor — not a directory copy.

Pieces:
- **`mkdocs_terok.versions`** — `plan` (select served snapshots from the GitHub release JSON: final tags with the asset, highest patch per minor, newest `keep` minors) and `assemble` (lay out dev + snapshots + `versions.json` + root redirect). Selection/layout logic testable here; the workflow does the IO.
- **`publish-versioned-docs.yml`** — reusable assemble-and-deploy workflow, run from the calling repo's locked docs env (the `publish-inventory.yml` contract). Callers grant `pages: write` + `id-token: write` + `contents: read`.
- **Inventory stripper** now also matches flow-mapping entries (`- { url: ..., base_url: ... }`).
- **Self-wiring**: this repo consumes the reusable workflow via a local reference (no chicken-egg), with an `attach` job shipping the snapshot asset on release.

## Why not mike

mike works fine against ProperDocs (verified: "Deployed … with ProperDocs 1.6.7 and mike 2.2.0") but is gh-pages-only; it cannot drive the stateless release-asset model chosen here.

## Why the stripper change / link-404 bug

Consumers switch inventory entries to mapping form with explicit `base_url`. Beyond versioning, this fixes a live bug: cross-repo API links on all published docs 404 into `raw.githubusercontent.com/terok-ai/docs-inventories/...` — mkdocstrings resolves relative inventory URIs against the inventory's own URL, and the bucket migration silently changed the link base.

## Rollout

Consumer PRs (terok#1117, util#32, clearance#174, shield#363, sandbox#413, executor#424) pin this PR branch for the dev cycle; then alpha gh-only wheel → repin → gradual master merges → PyPI bottom-up (mkdocs-terok first, then terok-util, then the rest).

**Manual step per repo**: the `github-pages` environment must allow deployments from `v*` tags (release deploys run on the tag ref). Pages source stays "GitHub Actions" — no settings flip needed.

## Checks

`pytest` (145), `ruff`, `docstr-coverage` 100%, `vulture`, `reuse lint`, `actionlint` — green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation sites can now be published in versioned form, with a dev version plus selectable historical versions.
  * Release workflows now publish docs automatically after a successful release.

* **Bug Fixes**
  * Improved handling of sibling inventory entries in documentation configuration, including additional YAML formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->