### PR TITLE
fix(workflow): unique pages_build_version per deploy

### DIFF
--- a/.github/workflows/publish-versioned-docs.yml
+++ b/.github/workflows/publish-versioned-docs.yml
@@ -49,7 +49,41 @@ on:
 permissions: {}
 
 jobs:
+  # Pages supports exactly one deployment per commit SHA: the API 404s
+  # any pages_build_version that is not a commit SHA, and a second
+  # deployment of the same SHA is silently ignored (or not — behaviour
+  # is unspecified).  See actions/deploy-pages#383.  So each SHA's one
+  # deployment must be the right one: a final v*.*.* tag on the pushed
+  # commit means a PyPI release is in flight (finals always ship to
+  # PyPI; alphas never do) and its versioned publish owns this SHA —
+  # the branch push yields.  Alpha and untagged pushes deploy dev here
+  # as usual, so gh-only releases need no deploy of their own.
+  target:
+    runs-on: ubuntu-latest
+    outputs:
+      deploy: ${{ steps.gate.outputs.deploy }}
+    steps:
+      - name: Yield branch pushes of final-release commits
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          deploy=true
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [[ "$GITHUB_REF" == refs/heads/* ]]; then
+            final_tags=$(gh api "repos/${GITHUB_REPOSITORY}/tags?per_page=100" --paginate \
+              --jq ".[] | select(.commit.sha == \"$GITHUB_SHA\") | .name" \
+              | grep -cE '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)
+            if [ "$final_tags" -gt 0 ]; then
+              deploy=false
+              echo "Commit carries a final release tag; the PyPI docs publish deploys it."
+            fi
+          fi
+          echo "deploy=$deploy" >> "$GITHUB_OUTPUT"
+
   publish:
+    needs: target
+    if: needs.target.outputs.deploy == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/versioned-docs.md
+++ b/docs/versioned-docs.md
@@ -1,0 +1,77 @@
+# Versioned docs publishing
+
+Every terok-`*` repo serves per-release documentation on GitHub Pages
+with Material's version chooser: master merges refresh `/dev/`, and
+each PyPI release adds a frozen `/<minor>/` snapshot. The machinery
+lives in this package — the
+[`publish-versioned-docs.yml`](https://github.com/terok-ai/mkdocs-terok/blob/master/.github/workflows/publish-versioned-docs.yml)
+reusable workflow and the
+[`mkdocs_terok.versions`][mkdocs_terok.versions] assembler it runs.
+
+## The model: stateless assembly
+
+There is no `gh-pages` branch and no stored site state. Each PyPI
+release ships its built site as an immutable `docs-site.tar.gz` asset
+on the GitHub release, and **every deploy reassembles the whole served
+tree from scratch**: the newest final release of each served minor,
+plus a fresh `/dev/` build, with `versions.json` (the chooser contract)
+derived from the release list. A deploy is a pure function of the
+release set and master — a botched one is fixed by re-running, and
+retention is just a parameter: the newest `keep` minors are served
+(default 6), older versions stay downloadable from their release
+assets forever. Alphas never reach PyPI, so they mint no snapshot and
+never appear in the chooser.
+
+## Consumer wiring
+
+A repo needs three pieces:
+
+1. **docs.yml, build job** — build the site exactly as before and
+   upload it as the `docs-site` artifact.
+2. **docs.yml, publish job** — hand it to the reusable workflow:
+
+    ```yaml
+    publish:
+      if: github.repository == 'terok-ai/<repo>' && (github.ref == 'refs/heads/master' || inputs.release)
+      needs: build
+      permissions:
+        contents: write
+        pages: write
+        id-token: write
+      uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@vX.Y.Z
+      with:
+        release: ${{ inputs.release == true }}
+    ```
+
+    with a `workflow_call` trigger exposing the boolean `release`
+    input. On a release call the same job first ships the snapshot
+    asset, so its own plan already sees the new release.
+
+3. **release.yml** — a `docs-version` job with `needs: pypi-publish`
+   calling docs.yml with `release: true`. Only what users can
+   `pip install` mints a docs version; gh-only and testpypi targets
+   publish nothing.
+
+Repo settings: Pages source **GitHub Actions**, and the `github-pages`
+environment must allow deployments from `v*` tags (release deploys run
+on the tag ref).
+
+In `properdocs.yml`, enable the chooser with
+`extra.version.provider: mike` — that names the `versions.json`
+contract Material reads, not the tool.
+
+## One deployment per commit
+
+GitHub Pages supports exactly one deployment per commit SHA: the API
+rejects any other `pages_build_version`, and a second deployment of
+the same SHA is silently ignored (or not — the behaviour is
+unspecified). See
+[actions/deploy-pages#383](https://github.com/actions/deploy-pages/issues/383).
+
+The workflow therefore makes sure each SHA's one deployment is the
+right one. A final `v*.*.*` tag on a pushed commit means a PyPI
+release is in flight and its versioned publish owns that SHA, so the
+branch-push deploy yields; alpha and untagged pushes deploy `/dev/` as
+usual, which also covers gh-only releases. If a final tag ever lands
+long after its merge (the release chain tags within seconds), the
+snapshot simply appears with the next merge.

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -54,6 +54,7 @@ plugins:
 
 nav:
   - Home: index.md
+  - Versioned Docs Publishing: versioned-docs.md
   - API Reference: reference/
   - CI Map: ci-map.md
   - Quality Report: code-metrics.md


### PR DESCRIPTION
## Bug

A release's docs snapshot can fail to go live: the versioned publish runs green, its plan selects the new `/X.Y/` snapshot, yet the site keeps serving the previous deployment.

Root cause: **GitHub Pages supports exactly one deployment per commit SHA.** `pages_build_version` must be a commit SHA (the API rejects anything else with a 404), and a second deployment of the same SHA is silently ignored — or occasionally isn't: the behaviour is unspecified. Upstream: [actions/deploy-pages#383](https://github.com/actions/deploy-pages/issues/383). Under merge-then-release, the release tag points at the master tip, so the release-PR merge push deploys first (dev-only — the snapshot asset doesn't exist yet) and claims the SHA; the release's versioned deploy then reports success without replacing anything. The tell in the logs: a real deploy polls status for ~5s, a no-op'd one "succeeds" in 0.2s.

## Fix

Make each SHA's single deployment the right one. A `target` gate job in the reusable workflow yields **branch pushes whose commit carries a final `v*.*.*` tag**: by release policy (final versions always ship to PyPI, alphas never do), such a tag means a PyPI release is in flight and its versioned publish owns that SHA's deployment. Alpha-tagged and untagged pushes deploy `/dev/` as usual — which also covers gh-only releases, since they change neither master nor the served release set.

Consumers need no wiring for this: the constraint handling lives entirely in the reusable workflow, and the trigger topology stays at its natural floor of two (master push, PyPI `docs-version`). Same-SHA redeploys are never relied on in either direction, since per #383 they are not even deterministically no-ops. If a final tag lands long after its merge (the release chain tags within seconds; the gate runs when the docs build finishes), the snapshot appears with the next merge.

## Docs

Adds a **Versioned Docs Publishing** page: the stateless assembly model, the three-piece consumer wiring including repo settings, retention, and the one-deployment-per-commit constraint with the upstream reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)