### PR TITLE
docs: accuracy pass against the current source

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,15 @@
 Shared [ProperDocs](https://properdocs.org/) documentation generators for terok projects.
 
 Provides reusable modules for generating CI workflow maps, integration test maps,
-code metrics reports, API reference pages, and config reference documentation from
-Pydantic models. A built-in `terok` ProperDocs plugin drives all generators
-automatically; the generator modules themselves never import the doc engine and can
-also be used standalone via `mkdocs-gen-files` shims.
+module maps, code metrics reports, API reference pages, and config reference
+documentation from Pydantic models. A built-in `terok` ProperDocs plugin drives
+every generator except the config reference (which needs a consumer-supplied
+Pydantic model); the generator modules themselves never import the doc engine and
+can also be used standalone via `mkdocs-gen-files` shims.
 
 The metrics report module can optionally parse output from
 [scc](https://github.com/boyter/scc),
-[complexipy](https://github.com/rohaquinern/complexipy),
+[complexipy](https://github.com/rohaquinlop/complexipy),
 [tach](https://github.com/gauge-sh/tach),
 [vulture](https://github.com/jendrikseipp/vulture), and
 [docstr-coverage](https://github.com/HunterMcGushion/docstr_coverage).
@@ -51,7 +52,7 @@ mkdocs-terok = "^0.7"
 
 Configured via the `terok` plugin in your `properdocs.yml`.  See this
 repository's own [`properdocs.yml`](properdocs.yml) for a self-documenting
-example that exercises every generator the package ships.
+example that exercises most of the generators the package ships.
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Shared [ProperDocs](https://properdocs.org/) documentation generators for [terok
 
 ## Overview
 
-`mkdocs-terok` is a **`terok` ProperDocs plugin** containig several documentation generators.
+`mkdocs-terok` is a **`terok` ProperDocs plugin** containing several documentation generators.
 For advanced use cases the generator modules are public and can be
 called directly via [`mkdocs-gen-files`](https://github.com/oprypin/mkdocs-gen-files).
 
@@ -46,18 +46,22 @@ content generation only.
 
 | Module | Purpose |
 |--------|---------|
-| `mkdocs_terok` | Package root — exports `brand_css_path()` and `mermaid_zoom_js_path()` |
+| `mkdocs_terok` | Package root — exports `brand_css_path()`, `mermaid_zoom_js_path()`, and `INVENTORY_ONLY_ENV` |
 | `mkdocs_terok.plugin` | ProperDocs `BasePlugin` wrapping all generators |
 | `mkdocs_terok.ref_pages` | Generate API reference pages from source tree |
 | `mkdocs_terok.ci_map` | Parse and visualize GitHub Actions workflows |
-| `mkdocs_terok.code_metrics` | Code quality analysis — optionally parses output from [scc](https://github.com/boyter/scc), [complexipy](https://github.com/rohaquinern/complexipy), [tach](https://github.com/gauge-sh/tach), [vulture](https://github.com/jendrikseipp/vulture), and [docstr-coverage](https://github.com/HunterMcGushion/docstr_coverage) (sections degrade gracefully when tools are absent) |
+| `mkdocs_terok.code_metrics` | Code quality analysis — optionally parses output from [scc](https://github.com/boyter/scc), [complexipy](https://github.com/rohaquinlop/complexipy), [tach](https://github.com/gauge-sh/tach), [vulture](https://github.com/jendrikseipp/vulture), and [docstr-coverage](https://github.com/HunterMcGushion/docstr_coverage) (sections degrade gracefully when tools are absent) |
 | `mkdocs_terok.test_map` | Generate test suite maps with marker extraction |
+| `mkdocs_terok.module_map` | Module and class docstrings grouped by layer (`tach.toml`-aware) |
 | `mkdocs_terok.config_reference` | Render Pydantic models as config documentation |
+| `mkdocs_terok.inventory` | Build the repo's `objects.inv` without needing sibling inventories |
+| `mkdocs_terok.versions` | Assemble the versioned docs tree from release snapshots — see [Versioned docs publishing](versioned-docs.md) |
 
 ## Dogfooding
 
-This documentation site **uses mkdocs-terok on itself**. Every generator in the
-library is exercised against this very repository via the `terok` plugin — see
+This documentation site **uses mkdocs-terok on itself**: the CI map, code
+metrics, test map, and reference page generators run via the `terok` plugin,
+and the config reference renderers run via a `mkdocs-gen-files` script — see
 [`properdocs.yml`](https://github.com/terok-ai/mkdocs-terok/blob/master/properdocs.yml)
 on master for the full live configuration.
 

--- a/docs/versioned-docs.md
+++ b/docs/versioned-docs.md
@@ -1,6 +1,6 @@
 # Versioned docs publishing
 
-Every terok-`*` repo serves per-release documentation on GitHub Pages
+Every `terok-*` repo serves per-release documentation on GitHub Pages
 with Material's version chooser: master merges refresh `/dev/`, and
 each PyPI release adds a frozen `/<minor>/` snapshot. The machinery
 lives in this package — the
@@ -63,9 +63,9 @@ contract Material reads, not the tool.
 ## One deployment per commit
 
 GitHub Pages supports exactly one deployment per commit SHA: the API
-rejects any other `pages_build_version`, and a second deployment of
-the same SHA is silently ignored (or not — the behaviour is
-unspecified). See
+404s any `pages_build_version` that is not a commit SHA, and a second
+deployment of the same SHA is silently ignored (or not — the behaviour
+is unspecified). See
 [actions/deploy-pages#383](https://github.com/actions/deploy-pages/issues/383).
 
 The workflow therefore makes sure each SHA's one deployment is the


### PR DESCRIPTION
Docs verified claim-by-claim against `src/mkdocs_terok/` and the workflows; corrections:

- **README / index**: "plugin drives all generators automatically" was false — the plugin drives `ci_map`, `code_metrics`, `test_map`, `module_map`, `ref_pages` (plugin.py), while `config_reference` is a plain library API fed by a consumer `mkdocs-gen-files` script; the dogfooding claim also named generators not enabled in this repo's own properdocs.yml (`module_map` isn't). Both now state exactly what runs where.
- **Modules table** was missing three real public modules — `module_map`, `inventory`, `versions` — and the package-root exports omitted `INVENTORY_ONLY_ENV`.
- **complexipy link** pointed at a nonexistent account (`rohaquinern` → `rohaquinlop`, verified via PyPI metadata).
- **versioned-docs.md**: the `pages_build_version` constraint is now stated exactly (API 404s non-SHA values) instead of vaguely; a `terok-*` formatting glitch fixed. All workflow-behavior claims on that page re-verified verbatim against `publish-versioned-docs.yml`/`docs.yml`/`release.yml` as they now stand (target gate, snapshot-before-plan ordering, keep=6, artifact contract, caller permissions, consumer `if:`).
- Typo (`containig`), README version-lint re-run green.

Left flagged, unverifiable from the repo: the `properdocs.org` link and the "release chain tags within seconds" claim (describes the external chain script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)