### PR TITLE
feat(versions): serve well-known root assets across versioned deploys

### DIFF
--- a/.github/workflows/publish-versioned-docs.yml
+++ b/.github/workflows/publish-versioned-docs.yml
@@ -37,6 +37,10 @@ on:
         description: "How many newest minors to serve; older releases stay downloadable as assets"
         type: number
         default: 6
+      root-assets:
+        description: "Space-separated site-relative files copied from the dev build to the served tree's root — well-known URLs that must survive versioning (e.g. logos hotlinked by READMEs on GitHub and PyPI)"
+        type: string
+        default: ""
       python-version:
         description: "Python version used to run the assembler"
         type: string
@@ -191,7 +195,11 @@ jobs:
                 --output "$RUNNER_TEMP/tarballs/$minor.tar.gz"
             done
 
+      # $ROOT_ASSETS expands unquoted on purpose: the input is a
+      # space-separated list feeding the CLI's nargs="*" flag.
       - name: Assemble the site tree
+        env:
+          ROOT_ASSETS: ${{ inputs.root-assets }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/snapshots"
@@ -203,7 +211,8 @@ jobs:
             --dev "$RUNNER_TEMP/dev-site" \
             --snapshots "$RUNNER_TEMP/snapshots" \
             --plan plan.json \
-            --out "$RUNNER_TEMP/tree"
+            --out "$RUNNER_TEMP/tree" \
+            --root-assets $ROOT_ASSETS
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/src/mkdocs_terok/versions.py
+++ b/src/mkdocs_terok/versions.py
@@ -15,7 +15,9 @@ release set and master.
 Retention is an assembly parameter: only the newest *keep* minors are
 served (the chooser and the site plateau instead of growing with the
 release cadence); older versions stay downloadable from their release
-assets forever.
+assets forever.  Root assets — files hotlinked at the site root by
+READMEs on GitHub and in immutable PyPI descriptions — are copied out
+of the dev build so their well-known URLs survive versioning.
 
 The module is IO-light on purpose: the ``publish-versioned-docs.yml``
 reusable workflow fetches the release list and downloads the snapshot
@@ -29,7 +31,8 @@ import argparse
 import json
 import re
 import shutil
-from pathlib import Path
+from collections.abc import Sequence
+from pathlib import Path, PurePosixPath
 
 #: Name of the per-release docs snapshot asset.
 DOCS_ASSET = "docs-site.tar.gz"
@@ -85,12 +88,27 @@ def plan(releases: list[dict], *, keep: int) -> list[dict]:
     ]
 
 
-def assemble(*, dev_site: Path, snapshots: Path, entries: list[dict], out: Path) -> None:
+def assemble(
+    *,
+    dev_site: Path,
+    snapshots: Path,
+    entries: list[dict],
+    out: Path,
+    root_assets: Sequence[str] = (),
+) -> None:
     """Lay out the complete site tree for a Pages deploy.
 
     Consumes its inputs: *dev_site* and the snapshot directories are
     moved into the tree, not copied — they are per-run scratch extracts,
     and a copy would double the whole served site on the deploy path.
+
+    *root_assets* are the site's well-known root URLs: files (READMEs
+    hotlink logos from GitHub and immutable PyPI descriptions) that must
+    stay reachable at ``<site>/<asset>`` even though the versioned tree
+    buries every build under a version directory.  Each is copied from
+    the dev build to the same path at the tree root — before the
+    assembler writes its own root files, so ``versions.json`` and the
+    redirect ``index.html`` can never be shadowed.
 
     Args:
         dev_site: Freshly built ProperDocs output for master.
@@ -99,20 +117,34 @@ def assemble(*, dev_site: Path, snapshots: Path, entries: list[dict], out: Path)
             [`plan`][mkdocs_terok.versions.plan].
         entries: The plan — newest minor first.
         out: Tree to create; replaced wholesale if it exists.
+        root_assets: Site-relative files to copy from the dev build to
+            the tree root.
 
     Raises:
-        ValueError: an entry's ``minor`` is not a plain ``X.Y`` name, or
-            *out* points at an existing non-empty directory that is not
-            a previously assembled tree (mispointed ``--out``).
+        ValueError: an entry's ``minor`` is not a plain ``X.Y`` name, a
+            root asset is not a plain relative path or is missing from
+            the dev build, or *out* points at an existing non-empty
+            directory that is not a previously assembled tree
+            (mispointed ``--out``).
     """
     for entry in entries:
         if not _MINOR.fullmatch(entry["minor"]):
             raise ValueError(f"unsafe minor in plan: {entry['minor']!r}")
+    for asset in root_assets:
+        parts = PurePosixPath(asset).parts
+        if not parts or parts[0] == "/" or ".." in parts:
+            raise ValueError(f"unsafe root asset: {asset!r}")
     _ensure_replaceable(out)
     if out.exists():
         shutil.rmtree(out)
     out.mkdir(parents=True)
     shutil.move(dev_site, out / "dev")
+    for asset in root_assets:
+        source = out / "dev" / asset
+        if not source.is_file():
+            raise ValueError(f"root asset missing from the dev build: {asset}")
+        (out / asset).parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, out / asset)
     for entry in entries:
         shutil.move(snapshots / entry["minor"], out / entry["minor"])
     chooser = [{"version": "dev", "title": "dev", "aliases": []}] + [
@@ -174,6 +206,13 @@ def _main(argv: list[str] | None = None) -> None:
     assemble_cmd.add_argument(
         "--out", type=Path, required=True, help="Tree to create for upload-pages-artifact"
     )
+    assemble_cmd.add_argument(
+        "--root-assets",
+        nargs="*",
+        default=[],
+        metavar="PATH",
+        help="Site-relative files copied from the dev build to the tree root (well-known URLs)",
+    )
 
     args = parser.parse_args(argv)
     if args.command == "plan":
@@ -184,6 +223,7 @@ def _main(argv: list[str] | None = None) -> None:
             snapshots=args.snapshots,
             entries=json.loads(args.plan.read_text()),
             out=args.out,
+            root_assets=args.root_assets,
         )
 
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -104,6 +104,51 @@ class TestAssemble:
                 dev_site=dev_site, snapshots=tmp_path / "none", entries=entries, out=tmp_path / "t"
             )
 
+    def test_root_assets_served_at_tree_root(
+        self, dev_site: Path, snapshots: Path, tmp_path: Path
+    ) -> None:
+        """Listed files stay reachable at the site root, nested paths included."""
+        (dev_site / "logo.svg").write_text("<svg>logo</svg>")
+        (dev_site / "img").mkdir()
+        (dev_site / "img" / "architecture.svg").write_text("<svg>arch</svg>")
+        out = tmp_path / "tree"
+
+        assemble(
+            dev_site=dev_site,
+            snapshots=snapshots,
+            entries=[{"minor": "0.9", "tag": "v0.9.1"}],
+            out=out,
+            root_assets=["logo.svg", "img/architecture.svg"],
+        )
+
+        assert (out / "logo.svg").read_text() == "<svg>logo</svg>"
+        assert (out / "img" / "architecture.svg").read_text() == "<svg>arch</svg>"
+        assert (out / "dev" / "logo.svg").is_file()
+        assert "url=0.9/" in (out / "index.html").read_text()
+
+    def test_missing_root_asset_fails_the_deploy(self, dev_site: Path, tmp_path: Path) -> None:
+        """A vanished asset must fail loudly, not publish broken well-known URLs."""
+        with pytest.raises(ValueError, match="missing from the dev build"):
+            assemble(
+                dev_site=dev_site,
+                snapshots=tmp_path / "none",
+                entries=[],
+                out=tmp_path / "tree",
+                root_assets=["gone.svg"],
+            )
+
+    @pytest.mark.parametrize("asset", ["../escape.svg", "/etc/passwd", "a/../../b", ""])
+    def test_rejects_unsafe_root_asset(self, dev_site: Path, tmp_path: Path, asset: str) -> None:
+        """A hand-crafted asset list must not steer copies outside the tree."""
+        with pytest.raises(ValueError, match="unsafe root asset"):
+            assemble(
+                dev_site=dev_site,
+                snapshots=tmp_path / "none",
+                entries=[],
+                out=tmp_path / "tree",
+                root_assets=[asset],
+            )
+
     def test_refuses_out_that_is_not_an_assembled_tree(
         self, dev_site: Path, tmp_path: Path
     ) -> None:
@@ -149,6 +194,7 @@ class TestMain:
         (dev / "index.html").write_text("dev")
         (tmp_path / "snapshots" / "0.8").mkdir(parents=True)
         (tmp_path / "snapshots" / "0.8" / "index.html").write_text("0.8")
+        (dev / "logo.svg").write_text("logo")
         plan_file = tmp_path / "plan.json"
         plan_file.write_text(plan_json)
         _main(
@@ -162,6 +208,9 @@ class TestMain:
                 str(plan_file),
                 "--out",
                 str(tmp_path / "tree"),
+                "--root-assets",
+                "logo.svg",
             ]
         )
         assert (tmp_path / "tree" / "0.8" / "index.html").read_text() == "0.8"
+        assert (tmp_path / "tree" / "logo.svg").read_text() == "logo"


### PR DESCRIPTION
## Problem

The versioned-docs assembly rebuilds the served Pages tree as `dev/` + released minors + `versions.json` + a redirect `index.html` — nothing else lives at the site root anymore. That regressed the brand-asset URLs the terok-* READMEs hotlink (`https://terok-ai.github.io/terok/terok-logo-b.svg` etc.): they now 404 on every GitHub repo page and on PyPI. Published PyPI descriptions are immutable (terok-util 's already carries these URLs), so the fix has to restore the URLs server-side — editing READMEs can't heal released pages.

## Fix

- `assemble()` gains `root_assets`: site-relative files copied from the fresh dev build to the tree root, right after the dev move and before the assembler writes its own root files (so `versions.json` / the redirect can never be shadowed). Unsafe paths (`..`, absolute) are rejected like unsafe minors; a missing asset fails the deploy loudly.
- CLI: `assemble --root-assets PATH ...` (`nargs="*"`, default empty).
- `publish-versioned-docs.yml` gains a `root-assets` string input (space-separated), plumbed to the CLI. Default empty — callers that don't declare root assets are unaffected.

## Follow-up

terok will pass `root-assets: terok-logo-w.svg terok-logo-b.svg casus-logo.svg hzdr-logo.svg img/architecture.svg` and bump its workflow ref to the release that ships this (companion PR in terok-ai/terok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)