### PR TITLE
feat(ci): host the fleet's reusable docs build

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,159 @@
+# Pin third-party actions to full commit SHAs for supply-chain security.
+# GitHub-owned actions (actions/*) may use version tags.
+#
+# Reusable ProperDocs site build for the terok package family
+# (terok-ai/terok-util#47 / #107 here).  Callers keep their triggers,
+# concurrency, and the publish handoff; this owns the build:
+#
+#   jobs:
+#     build:
+#       uses: terok-ai/mkdocs-terok/.github/workflows/docs-build.yml@vX.Y.Z
+#       with:
+#         coverage-workflow: analysis.yml
+#
+# Coverage handoff contract (well-known address): the workflow named by
+# ``coverage-workflow`` uploads an artifact ``coverage`` containing
+# reports/coverage.{json,xml}; it drives the code-coverage treemap so
+# the docs build never pays for a second test run.  Freshness policy:
+# master refs require the same-SHA run to succeed (20m wait); other
+# refs try same-SHA opportunistically and fall back to latest master.
+# The built site uploads as ``docs-site`` — the address
+# publish-versioned-docs.yml expects.
+
+name: Docs build (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      release:
+        description: "Building the release version derived from the tag ref (instead of dev)"
+        type: boolean
+        default: false
+      uv-sync-args:
+        description: "Args passed to ``uv sync`` for the docs environment"
+        type: string
+        default: "--locked --all-groups"
+      coverage-workflow:
+        description: "Workflow file that uploads the ``coverage`` artifact"
+        type: string
+        default: "analysis.yml"
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  build:
+    if: github.repository_owner == 'terok-ai'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync ${{ inputs.uv-sync-args }}
+
+      - name: Install scc (lines of code counter)
+        env:
+          SCC_SHA256: 6c31f4d0cf3b7a8c5ca910fa4e451949434798f6541ec5dea4b83f4973e13772
+        run: |
+          set -euo pipefail
+          curl -fsSLo /tmp/scc.tar.gz \
+            "https://github.com/boyter/scc/releases/download/v3.5.0/scc_Linux_x86_64.tar.gz"
+          echo "${SCC_SHA256}  /tmp/scc.tar.gz" | sha256sum -c -
+          sudo tar -xzf /tmp/scc.tar.gz -C /usr/local/bin scc
+
+      # On master, strictly require the coverage-producing run for *this*
+      # commit to have finished successfully - published docs must agree
+      # with published code.  Polling rather than ``workflow_run`` keeps
+      # this build visible as its own check.
+      - name: Wait for the coverage run on this commit (master)
+        if: github.ref == 'refs/heads/master'
+        uses: actions/github-script@v9
+        env:
+          COVERAGE_WORKFLOW: ${{ inputs.coverage-workflow }}
+        with:
+          script: |
+            const wf = process.env.COVERAGE_WORKFLOW;
+            const deadline = Date.now() + 20 * 60 * 1000;
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+            while (Date.now() < deadline) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: wf,
+                head_sha: context.sha,
+                per_page: 5,
+              });
+              const run = data.workflow_runs[0];
+              if (run?.status === 'completed') {
+                if (run.conclusion === 'success') {
+                  core.info(`${wf} succeeded for ${context.sha}`);
+                  return;
+                }
+                core.setFailed(
+                  `${wf} ${run.conclusion} for ${context.sha} — refusing to publish docs with a mismatched treemap`
+                );
+                return;
+              }
+              core.info(`${wf} for ${context.sha}: ${run?.status ?? 'not yet started'} — waiting`);
+              await sleep(20_000);
+            }
+            core.setFailed(`Timed out after 20m waiting for ${wf}`);
+
+      - name: Coverage artifact (master — same SHA, required)
+        if: github.ref == 'refs/heads/master'
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: ${{ inputs.coverage-workflow }}
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          name: coverage
+          path: reports
+          if_no_artifact_found: fail
+
+      # First push of a PR: the coverage run and this build start together,
+      # so this step usually misses and falls through to latest-master below.
+      - name: Coverage artifact (non-master — same SHA, best effort)
+        if: github.ref != 'refs/heads/master'
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: ${{ inputs.coverage-workflow }}
+          workflow_conclusion: completed
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: coverage
+          path: reports
+          if_no_artifact_found: warn
+
+      - name: Coverage artifact (non-master — fall back to latest master)
+        if: github.ref != 'refs/heads/master' && !hashFiles('reports/coverage.json')
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: ${{ inputs.coverage-workflow }}
+          workflow_conclusion: success
+          branch: master
+          name: coverage
+          path: reports
+          if_no_artifact_found: fail
+
+      - name: Build documentation
+        run: uv run properdocs build --strict
+
+      - name: Upload site for versioned publish
+        if: github.ref == 'refs/heads/master' || inputs.release
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-site
+          path: site/

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -62,8 +63,12 @@ jobs:
         with:
           enable-cache: true
 
+      # The input reaches the shell via env, not template interpolation —
+      # a workflow input must never be able to rewrite the run script.
       - name: Install dependencies
-        run: uv sync ${{ inputs.uv-sync-args }}
+        env:
+          UV_SYNC_ARGS: ${{ inputs.uv-sync-args }}
+        run: uv sync $UV_SYNC_ARGS
 
       - name: Install scc (lines of code counter)
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,97 +40,19 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # The build lives in docs-build.yml (reusable across the package
+  # family; hosted here).  The local ``./`` ref runs it at this very
+  # commit — sibling repos pin it by release tag instead.
   build:
     if: github.repository == 'terok-ai/mkdocs-terok' && (github.ref == 'refs/heads/master' || inputs.release)
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: read
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Set up Python
-        id: setup-python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install scc
-        env:
-          SCC_SHA256: 6c31f4d0cf3b7a8c5ca910fa4e451949434798f6541ec5dea4b83f4973e13772
-        run: |
-          set -euo pipefail
-          curl -fsSLo /tmp/scc.tar.gz \
-            "https://github.com/boyter/scc/releases/download/v3.5.0/scc_Linux_x86_64.tar.gz"
-          echo "${SCC_SHA256}  /tmp/scc.tar.gz" | sha256sum -c -
-          sudo tar -xzf /tmp/scc.tar.gz -C /usr/local/bin scc
-
-      - name: Install dependencies
-        # Dropped the `test` group: this workflow no longer runs pytest; the
-        # `coverage` artifact below carries everything the treemap needs.
-        run: uv sync --locked --group docs
-
-      # Wait for ci.yml's run on this commit to finish. CI is fast (no
-      # third-party services on the critical path), so this normally returns
-      # within seconds when the workflows are triggered together by a master
-      # push. Failing CI fails the docs deploy — published treemap must agree
-      # with published code.
-      - name: Wait for CI on this commit
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const deadline = Date.now() + 20 * 60 * 1000;
-            const sleep = ms => new Promise(r => setTimeout(r, ms));
-            while (Date.now() < deadline) {
-              const { data } = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'ci.yml',
-                head_sha: context.sha,
-                per_page: 5,
-              });
-              const run = data.workflow_runs[0];
-              if (run?.status === 'completed') {
-                if (run.conclusion === 'success') {
-                  core.info(`CI succeeded for ${context.sha}`);
-                  return;
-                }
-                core.setFailed(
-                  `CI ${run.conclusion} for ${context.sha} — refusing to publish docs with a mismatched treemap`
-                );
-                return;
-              }
-              core.info(`CI for ${context.sha}: ${run?.status ?? 'not yet started'} — waiting`);
-              await sleep(20_000);
-            }
-            core.setFailed('Timed out after 20m waiting for CI')
-
-      - name: Coverage artifact (same SHA, required)
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        with:
-          workflow: ci.yml
-          workflow_conclusion: success
-          commit: ${{ github.sha }}
-          name: coverage
-          path: reports
-          if_no_artifact_found: fail
-
-      - name: Build documentation
-        run: uv run properdocs build --strict
-
-      - name: Upload site for versioned publish
-        uses: actions/upload-artifact@v7
-        with:
-          name: docs-site
-          path: site/
+    uses: ./.github/workflows/docs-build.yml
+    with:
+      release: ${{ inputs.release == true }}
+      uv-sync-args: "--locked --group docs"
+      coverage-workflow: ci.yml
 
   # Local reference: this repo ships the reusable workflow, so it consumes
   # its own copy — consumers pin it by tag instead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ default-groups = ["dev", "test"]
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.8.0a1"
+fallback-version = "0.8.0a2"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mkdocs_terok"]


### PR DESCRIPTION
Implements #107, companion to terok-ai/terok-util#48 (wave 1 of terok-ai/terok-util#47).

- **`docs-build.yml`** (new, `workflow_call`): the ProperDocs build job every sibling carries verbatim — uv sync, SHA-pinned scc install, the coverage-artifact handoff (same-SHA run required on master with the 20m wait; opportunistic same-SHA + latest-master fallback on PR refs), `properdocs build --strict`, and the `docs-site` upload that `publish-versioned-docs.yml` consumes. Inputs only where the fleet genuinely varies: `uv-sync-args` (default `--locked --all-groups`; terok passes `--group docs`), `coverage-workflow` (default `analysis.yml`; this repo passes `ci.yml`), and the `release` flag threaded from the caller.
- **This repo's own `docs.yml`** becomes a thin caller via the **local `./` ref** — its master-only flow is exactly the reusable's master path, so the reusable is exercised on this repo's own master pushes and release builds before any consumer pins a tag.

Per the tags-throughout policy: after merge, the next gh-only alpha tag (`0.8.0a2`) is the first consumer-pinnable ref; the shield pilot PR consumes fleet-checks + no-git-deps (terok-util) and docs-build (here) together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable documentation build workflow.
  * Documentation builds now produce a downloadable site artifact for master and release builds.
  * Coverage reports are automatically retrieved and validated during master builds.

* **Refactor**
  * Streamlined the documentation workflow by centralizing build, coverage, and artifact handling in the reusable workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->