### PR TITLE
fix(docs-build): --no-sync on the properdocs run

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -154,7 +154,7 @@ jobs:
           if_no_artifact_found: fail
 
       - name: Build documentation
-        run: uv run properdocs build --strict
+        run: uv run --no-sync properdocs build --strict
 
       - name: Upload site for versioned publish
         if: github.ref == 'refs/heads/master' || inputs.release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ default-groups = ["dev", "test"]
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.8.0a2"
+fallback-version = "0.8.0a3"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mkdocs_terok"]


### PR DESCRIPTION
Unblocks terok-ai/terok-clearance#190: bare `uv run` re-syncs to default groups (dev+test), which on clearance builds dbus-python from source and dies. The env was synced one step earlier per `uv-sync-args`; `--no-sync` makes the build use it as-is. (This is the CodeRabbit `--no-sync` finding from the uv wave proving real on the one repo where it bites.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation build reliability by preventing unnecessary environment synchronization during the build process.
  * Documentation builds now run in strict mode to catch issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->