### PR TITLE
ci(deps): dependabot rides the uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@ updates:
     schedule:
       interval: "weekly"
 
-  # Python dependencies (pip ecosystem covers uv.lock/pyproject.toml)
-  - package-ecosystem: "pip"
+  # Python dependencies (uv ecosystem: pyproject.toml + uv.lock updated together)
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Deferred CodeRabbit finding from the uv port wave: `package-ecosystem: "pip"` doesn't update `uv.lock`, so its bump PRs would fail `uv sync --locked` in CI; the dedicated `uv` ecosystem updates `pyproject.toml` and `uv.lock` together. One-word change, no workflow files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)