### PR TITLE
build: ship the compact SPDX template

### DIFF
--- a/.reuse/templates/compact.jinja2
+++ b/.reuse/templates/compact.jinja2
@@ -1,0 +1,9 @@
+{% for copyright_line in copyright_lines %}
+{{ copyright_line }}
+{% endfor %}
+{% for contributor_line in contributor_lines %}
+SPDX-FileContributor: {{ contributor_line }}
+{% endfor %}
+{% for expression in spdx_expressions %}
+SPDX-License-Identifier: {{ expression }}
+{% endfor %}


### PR DESCRIPTION
Same gap as terok-ai/terok-util#68: `make spdx` calls `reuse annotate --template compact`, but `.reuse/templates/compact.jinja2` was never added here, so the documented way to add an SPDX header always died with `Template 'compact' could not be found`. Every other repo in the family ships the file; this is it, verbatim (0BSD license per this repo's target).

Verified: `make spdx` writes the standard header, `make reuse` stays compliant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated generated REUSE/SPDX metadata to include copyright statements, contributor information, and SPDX license identifiers.
  * Metadata entries are now emitted in a consistent, structured order for improved licensing clarity and compliance visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->