### PR TITLE
ci: address SonarCloud GitHub Actions analyzer findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
           SCC_SHA256: 6c31f4d0cf3b7a8c5ca910fa4e451949434798f6541ec5dea4b83f4973e13772
         run: |
           set -euo pipefail
-          curl -fsSLo /tmp/scc.tar.gz \
+          curl --proto '=https' --tlsv1.2 -fsSLo /tmp/scc.tar.gz \
             "https://github.com/boyter/scc/releases/download/v3.5.0/scc_Linux_x86_64.tar.gz"
           echo "${SCC_SHA256}  /tmp/scc.tar.gz" | sha256sum -c -
           sudo tar -xzf /tmp/scc.tar.gz -C /usr/local/bin scc
@@ -175,7 +175,7 @@ jobs:
         run: uv sync --locked --group docs
 
       - name: Build documentation
-        run: uv run properdocs build --strict
+        run: uv run --no-sync properdocs build --strict
 
       - name: Upload docs artifact
         if: github.event_name == 'pull_request'
@@ -200,4 +200,4 @@ jobs:
           enable-cache: true
 
       - name: Verify README renders for PyPI
-        run: uv run --no-project --with 'readme-renderer[md]' python -m readme_renderer README.md --format md
+        run: uv run --no-project --with 'readme-renderer[md]==45.0' python -m readme_renderer README.md --format md

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -75,7 +75,7 @@ jobs:
           SCC_SHA256: 6c31f4d0cf3b7a8c5ca910fa4e451949434798f6541ec5dea4b83f4973e13772
         run: |
           set -euo pipefail
-          curl -fsSLo /tmp/scc.tar.gz \
+          curl --proto '=https' --tlsv1.2 -fsSLo /tmp/scc.tar.gz \
             "https://github.com/boyter/scc/releases/download/v3.5.0/scc_Linux_x86_64.tar.gz"
           echo "${SCC_SHA256}  /tmp/scc.tar.gz" | sha256sum -c -
           sudo tar -xzf /tmp/scc.tar.gz -C /usr/local/bin scc


### PR DESCRIPTION
SonarCloud's automatic analysis recently gained a GitHub Actions analyzer; its new rules (S8541/S8544/S6506) fired on the workflow files and fail the quality gate on dependabot PRs #117/#118 (any PR touching the workflow files counts the pre-existing patterns as new-code issues).

Fixes applied here (the genuine ones):
- **S6506** — the scc download curls used `-L` without restricting protocols; now `--proto '=https' --tlsv1.2` (the sha256 check already prevented tampering, this closes the redirect nit properly).
- **S8544** — `uv run --with 'readme-renderer[md]'` was unpinned; now `==45.0`.
- docs build step now uses `uv run --no-sync` after `uv sync --locked`, consistent with the other jobs.

Not fixed, recommend marking **Accepted** in the SonarCloud UI:
- **S8541** (`--no-build` on every `uv sync`/`uv run`) — impractical: the project itself and `reuse` are sdist-only, so `--no-build` breaks installation. All deps come from the hash-locked `uv.lock`, which is the actual trust anchor.
- **S8544** on `uv sync $UV_SYNC_ARGS` in the reusable workflows — false positive: callers pass `--locked` through the input (the analyzer can't see through it).

Once this merges (making the analyzer findings part of the master baseline) a rebase of #117/#118 should bring their gates green, since their changed lines (action version bumps) carry no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security for automated documentation tooling downloads by requiring HTTPS and TLS 1.2.
  * Updated documentation builds to run with controlled dependency synchronization.
  * Pinned the README rendering verification tool to a specific version for more consistent checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->