### PR TITLE
ci: group dependabot GitHub Actions updates + align config with fleet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,31 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-
   # Python dependencies (uv ecosystem: pyproject.toml + uv.lock updated together)
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      dev-dependencies:
+        dependency-type: "development"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps(dev)"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"
+    groups:
+      internal-workflows:
+        patterns: ["terok-ai/*"]
+      external-actions:
+        patterns: ["*"]
+        exclude-patterns: ["terok-ai/*"]


### PR DESCRIPTION
Adds the internal/external `github-actions` groups (coalescing the reusable-workflow bump PRs, matching the sibling repos), and brings this repo’s dependabot config up to the fleet standard it was missing:

- `commit-message` prefixes (`deps` / `deps(dev)` / `ci`)
- `production-dependencies` / `dev-dependencies` groups for the `uv` ecosystem
- `day: monday` schedule to match the fleet

🤖 Generated with [Claude Code](https://claude.com/claude-code)